### PR TITLE
Add the REGEX filter  

### DIFF
--- a/lib/goo/base/filter.rb
+++ b/lib/goo/base/filter.rb
@@ -11,50 +11,54 @@ module Goo
       end
 
       def >(value)
-        @filter_tree << FILTER_TUPLE.new(:>,value)
+        @filter_tree << FILTER_TUPLE.new(:>, value)
         self
       end
 
       def <(value)
-        @filter_tree << FILTER_TUPLE.new(:<,value)
+        @filter_tree << FILTER_TUPLE.new(:<, value)
         self
       end
 
       def <=(value)
-        @filter_tree << FILTER_TUPLE.new(:<=,value)
+        @filter_tree << FILTER_TUPLE.new(:<=, value)
         self
       end
 
       def >=(value)
-        @filter_tree << FILTER_TUPLE.new(:>=,value)
+        @filter_tree << FILTER_TUPLE.new(:>=, value)
         self
       end
 
       def or(value)
-        @filter_tree << FILTER_TUPLE.new(:or,value)
+        @filter_tree << FILTER_TUPLE.new(:or, value)
         self
       end
 
       def ==(value)
-        @filter_tree << FILTER_TUPLE.new(:==,value)
+        @filter_tree << FILTER_TUPLE.new(:==, value)
         self
       end
 
       def and(value)
-        @filter_tree << FILTER_TUPLE.new(:and,value)
+        @filter_tree << FILTER_TUPLE.new(:and, value)
         self
       end
 
       def unbound
-        @filter_tree << FILTER_TUPLE.new(:unbound,nil)
+        @filter_tree << FILTER_TUPLE.new(:unbound, nil)
         self
       end
 
       def bound
-        @filter_tree << FILTER_TUPLE.new(:bound,nil)
+        @filter_tree << FILTER_TUPLE.new(:bound, nil)
         self
       end
 
+      def regex(value)
+        @filter_tree << FILTER_TUPLE.new(:regex, value)
+        self 
+      end
     end
   end
 end

--- a/lib/goo/sparql/queries.rb
+++ b/lib/goo/sparql/queries.rb
@@ -131,22 +131,29 @@ module Goo
           end
           filter_var = inspected_patterns[filter_pattern_match]
           if !filter_operation.value.instance_of?(Goo::Filter)
-            unless filter_operation.operator == :unbound || filter_operation.operator == :bound
+            case filter_operation.operator
+            when  :unbound
+              filter_operations << "!BOUND(?#{filter_var.to_s})"
+              return :optional
+
+            when :bound
+              filter_operations << "BOUND(?#{filter_var.to_s})"
+              return :optional
+            when :regex
+              if  filter_operation.value.is_a?(String)
+                filter_operations << "REGEX(?#{filter_var.to_s} , \"#{filter_operation.value.to_s}\")"
+              end
+
+            else
               value = RDF::Literal.new(filter_operation.value)
               if filter_operation.value.is_a? String
                 value = RDF::Literal.new(filter_operation.value, :datatype => RDF::XSD.string)
               end
               filter_operations << (
                 "?#{filter_var.to_s} #{sparql_op_string(filter_operation.operator)} " +
-                " #{value.to_ntriples}")
-            else
-              if filter_operation.operator == :unbound
-                filter_operations << "!BOUND(?#{filter_var.to_s})"
-              else
-                filter_operations << "BOUND(?#{filter_var.to_s})"
-              end
-              return :optional
+                  " #{value.to_ntriples}")
             end
+
           else
             filter_operations << "#{sparql_op_string(filter_operation.operator)}"
             query_filter_sparql(klass,filter_operation.value,filter_patterns,


### PR DESCRIPTION
# What is the SPARQl REGEX filter
see https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#func-regex
# Why
One of the use case, is for doing a simple terms search with out using the solr indexing 
# How to use it 
Using the [Students test data](https://github.com/ncbo/goo/blob/master/test/models.rb#L6)
``` ruby
f = Goo::Filter.new(:name).regex("n") # will find all students that contains "n" in there name
st = Student.where.filter(f).all # return "John" , "Daniel"  and  "Susan"
```

