### PR TITLE
Feature: Add regex filter

### DIFF
--- a/lib/goo/base/filter.rb
+++ b/lib/goo/base/filter.rb
@@ -11,50 +11,54 @@ module Goo
       end
 
       def >(value)
-        @filter_tree << FILTER_TUPLE.new(:>,value)
+        @filter_tree << FILTER_TUPLE.new(:>, value)
         self
       end
 
       def <(value)
-        @filter_tree << FILTER_TUPLE.new(:<,value)
+        @filter_tree << FILTER_TUPLE.new(:<, value)
         self
       end
 
       def <=(value)
-        @filter_tree << FILTER_TUPLE.new(:<=,value)
+        @filter_tree << FILTER_TUPLE.new(:<=, value)
         self
       end
 
       def >=(value)
-        @filter_tree << FILTER_TUPLE.new(:>=,value)
+        @filter_tree << FILTER_TUPLE.new(:>=, value)
         self
       end
 
       def or(value)
-        @filter_tree << FILTER_TUPLE.new(:or,value)
+        @filter_tree << FILTER_TUPLE.new(:or, value)
         self
       end
 
       def ==(value)
-        @filter_tree << FILTER_TUPLE.new(:==,value)
+        @filter_tree << FILTER_TUPLE.new(:==, value)
         self
       end
 
       def and(value)
-        @filter_tree << FILTER_TUPLE.new(:and,value)
+        @filter_tree << FILTER_TUPLE.new(:and, value)
         self
       end
 
       def unbound
-        @filter_tree << FILTER_TUPLE.new(:unbound,nil)
+        @filter_tree << FILTER_TUPLE.new(:unbound, nil)
         self
       end
 
       def bound
-        @filter_tree << FILTER_TUPLE.new(:bound,nil)
+        @filter_tree << FILTER_TUPLE.new(:bound, nil)
         self
       end
 
+      def regex(value)
+        @filter_tree << FILTER_TUPLE.new(:regex, value)
+        self 
+      end
     end
   end
 end

--- a/lib/goo/sparql/queries.rb
+++ b/lib/goo/sparql/queries.rb
@@ -131,22 +131,29 @@ module Goo
           end
           filter_var = inspected_patterns[filter_pattern_match]
           if !filter_operation.value.instance_of?(Goo::Filter)
-            unless filter_operation.operator == :unbound || filter_operation.operator == :bound
+            case filter_operation.operator
+            when  :unbound
+              filter_operations << "!BOUND(?#{filter_var.to_s})"
+              return :optional
+
+            when :bound
+              filter_operations << "BOUND(?#{filter_var.to_s})"
+              return :optional
+            when :regex
+              if  filter_operation.value.is_a?(String)
+                filter_operations << "REGEX(?#{filter_var.to_s} , \"#{filter_operation.value.to_s}\")"
+              end
+
+            else
               value = RDF::Literal.new(filter_operation.value)
               if filter_operation.value.is_a? String
                 value = RDF::Literal.new(filter_operation.value, :datatype => RDF::XSD.string)
               end
               filter_operations << (
                 "?#{filter_var.to_s} #{sparql_op_string(filter_operation.operator)} " +
-                " #{value.to_ntriples}")
-            else
-              if filter_operation.operator == :unbound
-                filter_operations << "!BOUND(?#{filter_var.to_s})"
-              else
-                filter_operations << "BOUND(?#{filter_var.to_s})"
-              end
-              return :optional
+                  " #{value.to_ntriples}")
             end
+
           else
             filter_operations << "#{sparql_op_string(filter_operation.operator)}"
             query_filter_sparql(klass,filter_operation.value,filter_patterns,

--- a/lib/goo/sparql/queries.rb
+++ b/lib/goo/sparql/queries.rb
@@ -141,7 +141,7 @@ module Goo
               return :optional
             when :regex
               if  filter_operation.value.is_a?(String)
-                filter_operations << "REGEX(?#{filter_var.to_s} , \"#{filter_operation.value.to_s}\")"
+                filter_operations << "REGEX(STR(?#{filter_var.to_s}) , \"#{filter_operation.value.to_s}\")"
               end
 
             else

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -496,6 +496,12 @@ class TestWhere < MiniTest::Unit::TestCase
     f = Goo::Filter.new(enrolled: [ :xxx ]).unbound
     st = Student.where.filter(f).all
     assert st.length == 7
+
+    f = Goo::Filter.new(:name).regex("n") # will find all students that contains "n" in there name
+    st = Student.where.filter(f).include(:name).all # return "John" , "Daniel"  and  "Susan"
+
+    assert_equal 3, st.length
+    assert_equal ["John","Daniel","Susan"].sort, st.map { |x| x.name }.sort
   end
 
   def test_aggregated


### PR DESCRIPTION
# What is the SPARQL REGEX filter
see https://www.w3.org/TR/2013/REC-sparql11-query-20130321/#func-regex

# Why

One of the possible use cases is for doing the search of a simple term without using the Solr indexing and instead directly using the SPARQL regex filter.

# How to use it 

Using the [Students test data](https://github.com/ncbo/goo/blob/master/test/models.rb#L6)
``` ruby
f = Goo::Filter.new(:name).regex("n") # will find all students that contain "n" in their name
st = Student.where.filter(f).all # return "John", "Daniel"  and  "Susan"
```

# Changes

- Add the regex filter helper
- Update query_filter_sparql to handle the REGEX filter
- Add a unit test for it in test_where.rb 
