### PR TITLE
Feature: Add portal languages preference 

### DIFF
--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -26,7 +26,9 @@ module Goo
   @@resource_options = Set.new([:persistent]).freeze
 
   # Define the languages from which the properties values will be taken
+  # It choose the first language that match otherwise return all the values
   @@main_languages = %w[en]
+
   @@configure_flag = false
   @@sparql_backends = {}
   @@model_by_name = {}

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -25,6 +25,8 @@ module Goo
 
   @@resource_options = Set.new([:persistent]).freeze
 
+  # Define the languages from which the properties values will be taken
+  @@main_languages = %w[en]
   @@configure_flag = false
   @@sparql_backends = {}
   @@model_by_name = {}
@@ -41,6 +43,19 @@ module Goo
   @@use_cache = false
 
   @@slice_loading_size = 500
+
+
+  def self.main_languages
+    @@main_languages
+  end
+  def self.main_languages=(lang)
+    @@main_languages = lang
+  end
+
+  def self.language_includes(lang)
+    lang_str = lang.to_s
+    main_languages.index { |l| lang_str.downcase.eql?(l) || lang_str.upcase.eql?(l)}
+  end
 
   def self.add_namespace(shortcut, namespace,default=false)
     if !(namespace.instance_of? RDF::Vocabulary)

--- a/lib/goo/sparql/loader.rb
+++ b/lib/goo/sparql/loader.rb
@@ -93,7 +93,8 @@ module Goo
         expand_equivalent_predicates(select, equivalent_predicates)
         solution_mapper = Goo::SPARQL::SolutionMapper.new aggregate_projections, bnode_extraction,
                                                           embed_struct, incl_embed, klass_struct, models_by_id,
-                                                          predicates_map, unmapped, variables, options
+                                                          predicates_map, unmapped, variables, incl, options
+
         solution_mapper.map_each_solutions(select)
       end
 
@@ -147,10 +148,10 @@ module Goo
           predicates_map = {}
           uniq_p.each do |p|
             i = 0
-            key = ("var_" + p.last_part + i.to_s).to_sym
+            key = ("var_#{p.last_part}#{i.to_s}").to_sym
             while predicates_map.include?(key)
               i += 1
-              key = ("var_" + p.last_part + i.to_s).to_sym
+              key = ("var_#{p.last_part}#{i.to_s}").to_sym
               break if i > 10
             end
             predicates_map[key] = p

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -47,7 +47,7 @@ module Goo
           elsif !not_matched_lang.empty?
             values = not_matched_lang
           end
-          values
+          values&.uniq
         end
 
         private

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -78,7 +78,9 @@ module Goo
         def matched_languages(index_values, model_attribute_val)
           not_matched_lang = index_values[:not_matched]
           matched_lang = index_values.reject { |key| key == :not_matched }
-          matched_lang[:no_lang] = Array(model_attribute_val) unless model_attribute_val.nil?
+          unless model_attribute_val.nil? || model_attribute_val.empty?
+            matched_lang[:no_lang] = Array(model_attribute_val)
+          end
           [matched_lang, not_matched_lang]
         end
       end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -1,0 +1,83 @@
+module Goo
+  module SPARQL
+    module Solution
+      class  LanguageFilter
+
+        def initialize
+          @other_languages_values = {}
+        end
+
+        def other_languages_values
+          @other_languages_values
+        end
+
+        def main_lang_filter(id, attr, old_values, new_value)
+          index, value = lang_index  old_values, new_value
+          save_other_lang_val(id, attr, index, new_value) unless index.eql? :no_lang
+          [index, value]
+        end
+
+        def fill_models_with_other_languages(models_by_id, list_attributes)
+          @other_languages_values.each  do |id, languages_values|
+            languages_values.each do |attr, index_values|
+              model_attribute_val = models_by_id[id].instance_variable_get("@#{attr.to_s}")
+              values = languages_values_to_set(index_values, model_attribute_val)
+
+              if !values.nil? && list_attributes.include?(attr)
+                models_by_id[id].send("#{attr.to_s}=", values || [], on_load: true)
+              elsif !values.nil?
+                models_by_id[id].send("#{attr.to_s}=", values.first || nil, on_load: true)
+              end
+            end
+          end
+        end
+
+        def languages_values_to_set(language_values, no_lang_values)
+
+          values = nil
+          matched_lang, not_matched_lang = matched_languages(language_values, no_lang_values)
+          if !matched_lang.empty?
+            main_lang = Array(matched_lang[:'0']) + Array(matched_lang[:no_lang])
+            secondary_languages = matched_lang.select { |key| key != :'0' && key != :no_lang }.sort.map { |x| x[1] }.flatten
+            values = main_lang + secondary_languages
+          elsif !not_matched_lang.empty?
+            values = not_matched_lang
+          end
+          values
+        end
+
+        private
+
+        def lang_index(object, new_value)
+          lang = new_value.language
+          if lang.nil?
+            [:no_lang, object]
+          else
+            index = Goo.language_includes(lang)
+            index = index ? index.to_s.to_sym : :not_matched
+            [index, new_value]
+          end
+        end
+
+        def save_other_lang_val(id, attr, index, value)
+          @other_languages_values[id] ||= {}
+          @other_languages_values[id][attr] ||= {}
+          @other_languages_values[id][attr][index] ||= []
+          
+          unless @other_languages_values[id][attr][index].include?(value.to_s)
+            @other_languages_values[id][attr][index] += Array(value.to_s)
+          end
+        end
+        
+
+
+        def matched_languages(index_values, model_attribute_val)
+          not_matched_lang = index_values[:not_matched]
+          matched_lang = index_values.reject { |key| key == :not_matched }
+          matched_lang[:no_lang] = Array(model_attribute_val) unless model_attribute_val.nil?
+          [matched_lang, not_matched_lang]
+        end
+      end
+    end
+  end
+end

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -78,7 +78,7 @@ module Goo
         def matched_languages(index_values, model_attribute_val)
           not_matched_lang = index_values[:not_matched]
           matched_lang = index_values.reject { |key| key == :not_matched }
-          unless model_attribute_val.nil? || model_attribute_val.empty?
+          unless model_attribute_val.nil? || Array(model_attribute_val).empty?
             matched_lang[:no_lang] = Array(model_attribute_val)
           end
           [matched_lang, not_matched_lang]

--- a/lib/goo/sparql/mixins/solution_lang_filter.rb
+++ b/lib/goo/sparql/mixins/solution_lang_filter.rb
@@ -38,8 +38,12 @@ module Goo
           matched_lang, not_matched_lang = matched_languages(language_values, no_lang_values)
           if !matched_lang.empty?
             main_lang = Array(matched_lang[:'0']) + Array(matched_lang[:no_lang])
-            secondary_languages = matched_lang.select { |key| key != :'0' && key != :no_lang }.sort.map { |x| x[1] }.flatten
-            values = main_lang + secondary_languages
+            if main_lang.empty?
+              secondary_languages = matched_lang.select { |key| key != :'0' && key != :no_lang }.sort.map { |x| x[1] }
+              values = secondary_languages.first
+            else
+              values = main_lang
+            end
           elsif !not_matched_lang.empty?
             values = not_matched_lang
           end

--- a/lib/goo/sparql/sparql.rb
+++ b/lib/goo/sparql/sparql.rb
@@ -1,6 +1,7 @@
 require "sparql/client"
 
 require_relative "mixins/query_pattern"
+require_relative "mixins/solution_lang_filter"
 require_relative "query_builder"
 require_relative "solutions_mapper"
 require_relative "client"


### PR DESCRIPTION
## Depend on PL

- https://github.com/ncbo/goo/pull/117

## Goal
Define a preference list of languages to choose to print/show in the portal. 

So if we set the languages configuration variable like so  `@@main_languages = ["en", "fr"]`, the API will **show only English values and values with no language tags**.
And secondly, if no English or language-tagged values found we **print french values**.
**Else print all the values**.

## Agroportal and SIFRportal use case

1. At SIFRportal we use this feature to give priority to French values ( using this configuration: `@@main_languages = ["fr"]` ) 
2. At Agrportal we choose to have french as a secondary language ( with the fact that in most cases our ontologies are in English or French), so we have set the main_languages to  ["en", "fr"] so that if **at Agroportal we have an ontology that is only in French, Spanish and German we will print French values**.  

## Related issues

- https://github.com/ontoportal-lirmm/goo/issues/6
- https://github.com/agroportal/documentation/issues/223
- https://github.com/ncbo/ontologies_linked_data/issues/114
- https://github.com/ncbo/goo/issues/95
- https://github.com/ncbo/ontologies_linked_data/issues/91