### PR TITLE
update addressable gem to v2.8

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ PATH
   remote: .
   specs:
     goo (0.0.2)
-      addressable (= 2.3.5)
+      addressable (~> 2.8)
       pry
       rdf (= 1.0.8)
       redis
@@ -30,7 +30,8 @@ GEM
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    addressable (2.3.5)
+    addressable (2.8.0)
+      public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
@@ -85,6 +86,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.7)
     rack (2.2.3)
     rack-accept (0.4.5)
       rack (>= 0.4)

--- a/goo.gemspec
+++ b/goo.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.email = "manuelso@stanford.edu"
   s.files = Dir["lib/**/*.rb"]
   s.homepage = "http://github.com/ncbo/goo"
-  s.add_dependency("addressable", "= 2.3.5")
+    s.add_dependency("addressable", "~> 2.8")
   s.add_dependency("pry")
   s.add_dependency("rdf", "= 1.0.8")
   s.add_dependency("redis")


### PR DESCRIPTION
newer version of addressable is needed for google-apis-analytics_v3 gem
used in ncbo_cron