### PR TITLE
Feature: Append new submission data by chunks to the triple store

### DIFF
--- a/lib/goo/sparql/client.rb
+++ b/lib/goo/sparql/client.rb
@@ -83,41 +83,28 @@ module Goo
       def append_triples_no_bnodes(graph,file_path,mime_type_in)
         bnodes_filter = nil
         dir = nil
-
-        if file_path.end_with?("ttl")
+        response = nil
+        if file_path.end_with?('ttl')
           bnodes_filter = file_path
         else
-          bnodes_filter,dir = bnodes_filter_file(file_path,mime_type_in)
+          bnodes_filter, dir = bnodes_filter_file(file_path, mime_type_in)
         end
-        mime_type = "text/turtle"
-
-        if mime_type_in == "text/x-nquads"
-          mime_type = "text/x-nquads"
-          graph = "http://data.bogus.graph/uri"
-        end
-
-        data_file = File.read(bnodes_filter)
-        params = {method: :post, url: "#{url.to_s}", headers: {"content-type" => mime_type, "mime-type" => mime_type}, timeout: nil}
-        backend_name = Goo.sparql_backend_name
-
-        if backend_name == BACKEND_4STORE
-          params[:payload] = {
-            graph: graph.to_s,
-            data: data_file,
-            "mime-type" => mime_type
-          }
-          #for some reason \\\\ breaks parsing
-          params[:payload][:data] = params[:payload][:data].split("\n").map { |x| x.sub("\\\\","") }.join("\n")
-        else
-          params[:url] << "?context=#{CGI.escape("<#{graph.to_s}>")}"
-          params[:payload] = data_file
+        chunk_lines = 500_000 # number of line
+        file = File.foreach(bnodes_filter)
+        lines = []
+        file.each_entry do |line|
+          lines << line
+          if lines.size == chunk_lines
+            response = execute_append_request graph, lines.join, mime_type_in
+            lines.clear
+          end
         end
 
-        response = RestClient::Request.execute(params)
+        response = execute_append_request graph, lines.join, mime_type_in unless lines.empty?
+
 
         unless dir.nil?
           File.delete(bnodes_filter)
-
           begin
             FileUtils.rm_rf(dir)
           rescue => e


### PR DESCRIPTION
This is an optimization PR.
Currently, in the parsing process after the RDF generation step, we do a "[delete and append to triple store"](https://github.com/ontoportal-lirmm/ontologies_linked_data)

```ruby
      def delete_and_append(triples_file_path, logger, mime_type = nil)
        Goo.sparql_data_client.delete_graph(self.id)
        Goo.sparql_data_client.put_triples(self.id, triples_file_path, mime_type)
        logger.info("Triples #{triples_file_path} appended in #{self.id.to_ntriples}")
        logger.flush
      end
```
In the append triples step, we [transform the XRDF to Turtle in a temporary file](https://github.com/ontoportal-lirmm/goo/blob/master/lib/goo/sparql/client.rb#L90)
Then we do a [single "post" request to the triple store](https://github.com/ontoportal-lirmm/goo/blob/master/lib/goo/sparql/client.rb#L100) containing the turtle file as the request body.

The issue is when we have a big file (>= 1GB) (like in our use case here https://github.com/ontoportal-lirmm/ontologies_linked_data/issues/15) is not an efficient way to submit all the content file in a unique HTTP request

The PR changes the function `append_triples_no_bnodes` to do the append by chunks of 500 000 lines (triples) per request

With the use case of TAXREF-LD 
- Size : 870,3 Mb
- Pasred file size: 1,71 Go Gb
- Turtle version appended to the triple store: 2.1Gb

Before the change we had 
```
Mar  1 12:25:38 agroportal 4store[28359]: httpd.c:598 starting add to http://data.bioontology.org/ontologies/TAXREF-LD/submissions/2 (2179291409 bytes)
Mar  1 12:25:38 agroportal 4s-httpd: 4store[28359]: httpd.c:598 starting add to http://data.bioontology.org/ontologies/TAXREF-LD/submissions/2 (2179291409 bytes)
Mar  1 12:25:43 agroportal 4store[28359]: import.c:167 Fatal error: out of dynamic memory in turtle_lexer__scan_bytes() at 1
Mar  1 12:25:43 agroportal 4s-httpd: 4store[28359]: import.c:167 Fatal error: out of dynamic memory in turtle_lexer__scan_bytes() at 1
Mar  1 12:25:43 agroportal 4store[12682]: httpd.c:1979 child 28359 terminated by signal 11
Mar  1 12:25:43 agroportal 4s-httpd: 4store[12682]: httpd.c:1979 child 28359 terminated by signal 11
```

After the change, it worked and we have the following benchmark
Objects Freed: 572924847
Time: 734.6 seconds
Memory usage: 618.36 MB (Before the memory usage was dependent and equal to the append Turtle version  of the file, now it will never exceed 700MB)

Reference : https://tjay.dev/howto-working-efficiently-with-large-files-in-ruby/