### PR TITLE
Improve email validator: stricter format checks and length limits

### DIFF
--- a/lib/goo/validators/implementations/email.rb
+++ b/lib/goo/validators/implementations/email.rb
@@ -2,21 +2,48 @@ module Goo
   module Validators
     class Email < ValidatorBase
       include Validator
-      EMAIL_REGEXP = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+      # Matches reasonably valid emails (no double dots, no leading/trailing dots or hyphens, valid domain)
+      EMAIL_REGEXP = /\A
+      [a-z0-9!#$%&'*+\/=?^_`{|}~-]+             # local part
+      (?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*       # dot-separated continuation in local
+      @
+      (?:(?!-)[a-z0-9-]{1,63}(?<!-)\.)+          # domain labels
+      [a-z]{2,}                                  # top-level domain (at least 2 chars)
+      \z/ix      
+
+      MIN_LENGTH = 6       # Smallest valid email: a@b.cd
+      MAX_LENGTH = 254     # RFC 5321 limits email length to 254 characters 
+      LOCAL_PART_MAX = 64  # Per RFC
+      DOMAIN_PART_MAX = 253
+      
       key :email
 
       error_message ->(obj) {
         if @value.kind_of? Array
-          return "All values in attribute `#{@attr}` must be a valid emails"
+          return "All values in attribute `#{@attr}` must be valid email addresses"
         else
-          return "Attribute `#{@attr}` with the value `#{@value}` must be a valid email"
-
+          return "Attribute `#{@attr}` with the value `#{@value}` must be a valid email address"
         end
       }
 
-      validity_check -> (obj) do
-        @value.nil? || @value.match?(EMAIL_REGEXP)
+      private
+
+      validity_check ->(obj) do
+        return true if @value.nil?
+
+        values = @value.is_a?(Array) ? @value : [@value]
+
+        values.all? do |email|
+          next false unless email.is_a?(String)
+          next false unless email.length.between?(MIN_LENGTH, MAX_LENGTH)
+
+          local, domain = email.split('@', 2)
+          next false if local.nil? || domain.nil?
+          next false if local.length > LOCAL_PART_MAX || domain.length > DOMAIN_PART_MAX
+
+          email.match?(EMAIL_REGEXP)
+        end
       end
     end
   end
-end
+end 

--- a/test/test_email_validator.rb
+++ b/test/test_email_validator.rb
@@ -1,0 +1,85 @@
+require_relative 'test_case.rb'
+
+module Goo
+  module Validators
+    class TestEmail < MiniTest::Unit::TestCase
+
+      def dummy_instance
+        @dummy ||= Object.new
+      end
+
+      def validate(value)
+        Email.new(dummy_instance, :email, value)
+      end
+
+      def assert_valid(value)
+        validator = validate(value)
+        assert validator.valid?, "Expected #{value.inspect} to be valid"
+      end
+
+      def assert_invalid(value)
+        validator = validate(value)
+        refute validator.valid?, "Expected #{value.inspect} to be invalid"
+      end
+
+      def test_valid_emails
+        assert_valid nil
+        assert_valid "user@example.com"
+        assert_valid "john.doe+test@sub.domain.org"
+        assert_valid "a_b-c@foo-bar.co.uk"
+        assert_valid "user123@domain.io"
+      end
+
+      def test_invalid_emails_structure
+        assert_invalid ""
+        assert_invalid "plainaddress"
+        assert_invalid "user@localhost"
+        assert_invalid "user@com"
+        assert_invalid "user@.com"
+        assert_invalid "user@com."
+        assert_invalid "user@-domain.com"
+        assert_invalid "user@domain-.com"
+        assert_invalid "user.@example.com"
+        assert_invalid "user..user@example.com"
+        assert_invalid "user@domain..com"
+        assert_invalid "user@"
+      end
+
+      def test_email_length_limits
+        too_short = "a@b.c"  # 5 chars
+        assert_invalid too_short
+
+        long_local = "a" * 65
+        assert_invalid "#{long_local}@example.com"
+
+        long_domain = ("a" * 63 + ".") * 4 + "com"
+        assert_invalid "user@#{long_domain}"
+
+        too_long = "#{'a'*64}@#{'b'*189}.com"  # 258 chars
+        assert_invalid too_long
+      end
+
+      def test_array_with_all_valid_emails
+        validator = validate(["valid@example.com", "foo.bar@domain.co"])
+        assert validator.valid?
+      end
+
+      def test_array_with_one_invalid_email
+        validator = validate(["good@domain.com", "bad@domain..com"])
+        refute validator.valid?
+      end
+
+      def test_error_message_for_single_invalid_email
+        validator = validate("invalid-email")
+        refute validator.valid?
+        assert_match(/must be a valid email address/i, validator.error)
+      end
+
+      def test_error_message_for_array_with_invalid
+        validator = validate(["invalid@", "also@bad"])
+        refute validator.valid?
+        assert_match(/All values.*must be valid email addresses/i, validator.error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Rejects consecutive dots and invalid domain structures
- Enforces max length for email, local part, and domain part
- Adds comprehensive unit tests covering edge cases