### PR TITLE
New validators to check for valid usernames and text considered 'safe'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ncbo/sparql-client.git
-  revision: 1657f0dd69fd4b522d3549a6848670175f5e98cc
+  revision: 86c873a0d2873794489126c3c85165234785a96b
   branch: develop
   specs:
     sparql-client (1.0.1)

--- a/lib/goo/validators/enforce.rb
+++ b/lib/goo/validators/enforce.rb
@@ -26,13 +26,13 @@ module Goo
             when :existence
               check Goo::Validators::Existence, inst, attr, value, opt
             when :list, Array
-              check Goo::Validators::DataType, inst, attr, value,opt, Array
+              check Goo::Validators::DataType, inst, attr, value, opt, Array
             when :uri, RDF::URI
-              check Goo::Validators::DataType, inst, attr, value,opt, RDF::URI
+              check Goo::Validators::DataType, inst, attr, value, opt, RDF::URI
             when :string, String
-              check Goo::Validators::DataType, inst, attr, value,opt, String
+              check Goo::Validators::DataType, inst, attr, value, opt, String
             when :integer, Integer
-              check Goo::Validators::DataType, inst, attr, value,opt, Integer
+              check Goo::Validators::DataType, inst, attr, value, opt, Integer
             when :boolean
               check Goo::Validators::DataType, inst, attr, value, opt,:boolean
             when :date_time, DateTime
@@ -43,6 +43,8 @@ module Goo
               check Goo::Validators::Symmetric, inst, attr, value, opt
             when :email
               check Goo::Validators::Email, inst, attr, value, opt
+            when :username
+              check Goo::Validators::Username, inst, attr, value, opt
             when /^distinct_of_/
               check Goo::Validators::DistinctOf, inst, attr, value, opt, opt
             when /^superior_equal_to_/
@@ -54,6 +56,8 @@ module Goo
             when /^max_/, /^min_/
               type = opt.to_s.index("max_") ? :max : :min
               check Goo::Validators::ValueRange, inst, attr, value, type, opt.to_s
+            when /^safe_text/
+              check Goo::Validators::SafeText, inst, attr, value, opt, opt.to_s
             else
               if object_type?(opt)
                 check_object_type inst, attr, value, opt

--- a/lib/goo/validators/implementations/safe_text.rb
+++ b/lib/goo/validators/implementations/safe_text.rb
@@ -1,0 +1,54 @@
+module Goo
+  module Validators
+    class SafeText < ValidatorBase
+      include Validator
+
+      SAFE_TEXT_REGEX = /\A[\p{L}\p{N} .,'\-@()&!$%\/\[\]:;]+\z/u.freeze
+      DISALLOWED_UNICODE = /[\u0000-\u001F\u007F\u00A0\u200B-\u200F\u2028-\u202F\u202E\u2066-\u2069]/u.freeze
+
+      key :safe_text
+
+      error_message ->(obj) {
+        # Truncate long string values for clarity
+        truncated_value = if @value.is_a?(String) && @value.length > 60
+                            "#{@value[0...57]}..."
+                          else
+                            @value
+                          end
+
+        prefix = if @value.is_a?(Array)
+                   "All values in attribute `#{@attr}`"
+                 else
+                   "Attribute `#{@attr}` with the value `#{truncated_value}`"
+                 end
+
+        suffix = "must be safe text (no control or invisible Unicode characters, newlines, or disallowed punctuation)"
+        length_note = @max_length ? " and must not exceed #{@max_length} characters" : ""
+
+        "#{prefix} #{suffix}#{length_note}"
+      }
+
+      validity_check ->(obj) do
+        return true if @value.nil?
+
+        Array(@value).all? do |val|
+          next false unless val.is_a?(String)
+
+          length_ok = @max_length.nil? || val.length <= @max_length
+          length_ok &&
+            val !~ /\R/ &&
+            val =~ SAFE_TEXT_REGEX &&
+            val !~ DISALLOWED_UNICODE
+        end
+      end
+
+      def initialize(inst, attr, value, opt)
+        @max_length = nil
+        super(inst, attr, value)
+        match = opt.match(/_(\d+)$/)
+        @max_length = match[1].to_i if match && match[1]
+      end
+
+    end
+  end
+end

--- a/lib/goo/validators/implementations/username.rb
+++ b/lib/goo/validators/implementations/username.rb
@@ -1,0 +1,45 @@
+module Goo
+  module Validators
+    class Username < ValidatorBase
+      include Validator
+
+      RESERVED_NAMES = %w[
+        admin administrator root support system test guest owner user
+        webmaster help contact host mail ftp info api noc security
+      ].freeze
+
+      USERNAME_LENGTH_RANGE = (3..32).freeze
+
+      ASCII_ONLY_REGEX = /\A[\x20-\x7E]+\z/
+      USERNAME_PATTERN = /\A[a-zA-Z](?!.*[._]{2})[a-zA-Z0-9._]{1,30}[a-zA-Z0-9]\z/
+      INVISIBLE_CHARS = /[\u200B-\u200D\uFEFF]/
+
+      key :username
+
+      error_message ->(obj) {
+        base_msg = if @value.is_a?(Array)
+                     "All values in attribute `#{@attr}` must be valid usernames"
+                   else
+                     "Attribute `#{@attr}` with the value `#{@value}` must be a valid username"
+                   end
+        "#{base_msg} (must be 3–32 chars, start with a letter, contain only ASCII letters/digits/dots/underscores, no invisible or reserved terms)"
+      }
+
+      validity_check ->(obj) do
+        return true if @value.nil?
+
+        Array(@value).all? do |username|
+          next false unless username.is_a?(String)
+
+          username = username.strip
+
+          USERNAME_LENGTH_RANGE.cover?(username.length) &&
+            username.match?(ASCII_ONLY_REGEX) &&
+            username.match?(USERNAME_PATTERN) &&
+            !username.match?(INVISIBLE_CHARS) &&
+            !RESERVED_NAMES.include?(username.downcase)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- New validator: `:username`. Used to flush out username that do not adhere to the best industry practices.
  - Must be 3–32 chars
  - Must start with a letter
  - Must contain only ASCII letters/digits/dots/underscores
  - Must NOT include invisible or reserved terms
  - Usage: `attribute :username, enforce: [:string, :existence, :username]`
- New validator: `:safe_text`. Used to reject text that includes non-standard characters that are often used to exploit the system.
  - Prevents the use of control or invisible Unicode characters, newlines, or disallowed punctuation 
  - Allows passing an optional length limiter by specifying a number at the end of the attribute, i.e. `:safe_text_50`
  - Usage: 
    - `attribute :name, enforce: [:existence, :safe_text_50]`  
    - `attribute :description, enforce: [:safe_text]`  