### PR TITLE
Feature: `:url` data type validation for restricting URIs to http schema

### DIFF
--- a/lib/goo/validators/enforce.rb
+++ b/lib/goo/validators/enforce.rb
@@ -29,6 +29,8 @@ module Goo
               check Goo::Validators::DataType, inst, attr, value, opt, Array
             when :uri, RDF::URI
               check Goo::Validators::DataType, inst, attr, value, opt, RDF::URI
+            when :url
+              check Goo::Validators::DataType, inst, attr, value, opt, :url
             when :string, String
               check Goo::Validators::DataType, inst, attr, value, opt, String
             when :integer, Integer

--- a/lib/goo/validators/implementations/data_type.rb
+++ b/lib/goo/validators/implementations/data_type.rb
@@ -54,21 +54,10 @@ module Goo
         end
       end
 
-      
       def enforce_type_url(value)
         return true if value.nil?
         return value.all? { |x| url?(x) } if value.is_a?(Array)
         url?(value)
-      end
-
-      def enforce_type_url1(value)
-        return true if value.nil?
-
-        if value.is_a? Array
-          value.reject { |x| url?(x) }.empty?
-        else
-          url?(value)
-        end
       end
 
       def enforce_type_boolean(value)
@@ -87,8 +76,8 @@ module Goo
         value.is_a?(RDF::URI) && value.valid?
       end
 
-      def url?(val)
-        s = val.to_s
+      def url?(value)
+        s = value.to_s
         return false if s.empty? || s.length > MAX_URL_LENGTH
 
         uri = URI.parse(s)
@@ -96,7 +85,6 @@ module Goo
       rescue URI::InvalidURIError
         false
       end
-
     end
   end
 end

--- a/test/test_url_validator.rb
+++ b/test/test_url_validator.rb
@@ -1,0 +1,63 @@
+require_relative 'test_case'
+require 'goo/validators/validator'
+require 'goo/validators/implementations/data_type'
+require 'rdf'
+
+class UrlTestModel < Goo::Base::Resource
+  model :url_test_model, name_with: :name
+  attribute :url, enforce: %i[url]
+  attribute :urls, enforce: %i[list url]
+end
+
+class UrlValidatorTest < Minitest::Unit::TestCase
+  def test_url_scalar
+    u = UrlTestModel.new
+    u.url = RDF::URI.new('https://example.com/path?x=1')
+    assert u.valid?, "expected https URL to be valid, got errors: #{u.errors.inspect}"
+
+    u.url = [RDF::URI.new('https://example.com/path?x=1')]
+    refute u.valid?, "expected to reject array, got errors: #{u.errors.inspect}"
+    assert u.errors[:url][:no_list], "errors: #{u.errors.inspect}"
+  end
+
+  def test_url_scalar_rejects_non_http_schemes
+    [
+      '', 'http://', 'wrong/uri', 'mailto:user@nodomain.org', 'ftp://test.com/',
+      'urn:isbn:123456', 'ssh://root@localhost:22', 'file:///etc/passwd',
+      'http://', 'http://[::gggg]',
+      '//example.org/path',
+      "https://example.com/too_long_url/#{'a' * 2050}"
+    ].each do |bad|
+      u = UrlTestModel.new
+      u.url = RDF::URI.new(bad)
+      refute u.valid?, "expected invalid for #{bad.inspect}"
+      assert u.errors[:url][:url], "expected :url error key for #{bad.inspect}"
+    end
+  end
+
+  def test_url_list
+    u = UrlTestModel.new
+    u.urls = [RDF::URI.new('http://example.com/'),
+              RDF::URI.new('https://example2.com/ok')]
+    assert u.valid?, "expected valid list of URLs, got: #{u.errors.inspect}"
+
+    u.urls = [RDF::URI.new('https://example.com/')]
+    assert u.valid?
+
+    u.urls = RDF::URI.new('http://example.com/')
+    refute u.valid?
+    assert u.errors[:urls]
+  end
+
+  def test_url_list_must_all_be_valid
+    u = UrlTestModel.new
+    u.urls = [RDF::URI.new('https://ok.example'),
+              RDF::URI.new('mailto:bad@example.org')]
+    refute u.valid?
+    assert u.errors[:urls][:url]
+
+    u.urls = [RDF::URI.new('https://ok.example'), true]
+    refute u.valid?
+    assert u.errors[:urls][:url]
+  end
+end


### PR DESCRIPTION
## Feature: add `:url` data type (restrict to HTTP/HTTPS)

### What

- Introduces `:url` validator that accepts only absolute HTTP/HTTPS URLs with a non-empty host.
- Enforces a maximum length of 2048 characters (URLs longer than 2048 are rejected).
- Leaves existing `:uri` semantics unchanged.

### Why

`:uri` is intentionally broad (e.g., accepts `mailto:…`, `file:///…`, etc.).
Some attributes (e.g., `pullLocation`, `documentation`, `publication`) are rendered as links or used for remote fetches and should be limited to HTTP/HTTPS.

### Scope

- DataType#url? implementation (URI.parse, URI::HTTP, host present, length ≤ 2048).
- enforce_type(:url) branch.
- Enforce: dispatch :url to DataType.
- Unit tests for scalar, list, mixed invalid, and shape (:list) cases.

### Non-goals

Comprehensive SSRF protection (DNS/IP checks, private network blocking, allow/deny lists) — to be handled higher in the stack to keep core data validation lightweight.

see:
- https://github.com/ncbo/goo/issues/164