### PR TITLE
Allow the :bypass_cache param to propogate from the GOO to sparql-client

### DIFF
--- a/lib/goo/sparql/solutions_mapper.rb
+++ b/lib/goo/sparql/solutions_mapper.rb
@@ -43,6 +43,8 @@ module Goo
           select.prefix('franzOption_allowCachingResults: <franz:yes>')
         end
 
+        select.options[:bypass_cache] = @options[:bypass_cache] if @options.has_key?(:bypass_cache)
+
         # for troubleshooting specific queries (write 1 of 3)
         # ont_to_parse = 'OAE'
         # sub_id = 171


### PR DESCRIPTION
The SPARQL Client `query` method accepts an optional parameter, `:bypass_cache => true|false`:

https://github.com/ncbo/sparql-client/blob/master/lib/sparql/client.rb#L279

However, that parameter, even when passed by the higher API calls, gets muted and never makes it to the SPARQL Client layer. This change allows this parameter to propagate to the `query` method of the SPARQL Client. 

For example:
```
ont = Ontology.find(params["acronym"], bypass_cache: true).include(:acronym, :administeredBy, :acl, :viewingRestriction, submissions: :submissionId).first
```