### PR TITLE
Tighten email and username validators

### DIFF
--- a/lib/goo/validators/implementations/email.rb
+++ b/lib/goo/validators/implementations/email.rb
@@ -2,13 +2,18 @@ module Goo
   module Validators
     class Email < ValidatorBase
       include Validator
-      # Matches reasonably valid emails (no double dots, no leading/trailing dots or hyphens, valid domain)
+      DOMAIN_LABEL = /(?!-)[a-z0-9-]{1,63}(?<!-)/
+      TLD_LABEL = /(?:[a-z]{2,}|xn--(?!-)[a-z0-9-]{1,59}(?<!-))/
+
+      # Matches reasonably valid ASCII email addresses.
+      # This validator intentionally does not support non-ASCII local parts or Unicode domains;
+      # internationalized domains must be provided in ASCII punycode form.
       EMAIL_REGEXP = /\A
       [a-z0-9!#$%&'*+\/=?^_`{|}~-]+             # local part
       (?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*       # dot-separated continuation in local
       @
-      (?:(?!-)[a-z0-9-]{1,63}(?<!-)\.)+          # domain labels
-      [a-z]{2,}                                  # top-level domain (at least 2 chars)
+      (?:#{DOMAIN_LABEL}\.)+                     # domain labels
+      #{TLD_LABEL}                               # top-level domain or punycode TLD
       \z/ix
 
       MIN_LENGTH = 6       # Smallest valid email: a@b.cd

--- a/lib/goo/validators/implementations/email.rb
+++ b/lib/goo/validators/implementations/email.rb
@@ -12,8 +12,8 @@ module Goo
       [a-z0-9!#$%&'*+\/=?^_`{|}~-]+             # local part
       (?:\.[a-z0-9!#$%&'*+\/=?^_`{|}~-]+)*       # dot-separated continuation in local
       @
-      (?:#{DOMAIN_LABEL}\.)+                     # domain labels
-      #{TLD_LABEL}                               # top-level domain or punycode TLD
+      (?:#{DOMAIN_LABEL.source}\.)+              # domain labels
+      #{TLD_LABEL.source}                        # top-level domain or punycode TLD
       \z/ix
 
       MIN_LENGTH = 6       # Smallest valid email: a@b.cd

--- a/lib/goo/validators/implementations/username.rb
+++ b/lib/goo/validators/implementations/username.rb
@@ -4,7 +4,7 @@ module Goo
       include Validator
 
       RESERVED_NAMES = %w[
-        admin administrator root support system test guest owner user
+        root support system test guest owner user
         webmaster help contact host mail ftp info api noc security
       ].freeze
 
@@ -30,8 +30,7 @@ module Goo
 
         Array(@value).all? do |username|
           next false unless username.is_a?(String)
-
-          username = username.strip
+          next false unless username == username.strip
 
           USERNAME_LENGTH_RANGE.cover?(username.length) &&
             username.match?(ASCII_ONLY_REGEX) &&

--- a/test/test_email_validator.rb
+++ b/test/test_email_validator.rb
@@ -28,6 +28,9 @@ module Goo
         assert_valid "john.doe+test@sub.domain.org"
         assert_valid "a_b-c@foo-bar.co.uk"
         assert_valid "user123@domain.io"
+        # punycode TLD domains
+        assert_valid "user@example.xn--p1ai"
+        assert_valid "user@sub.domain.xn--p1ai"
       end
 
       def test_invalid_emails_structure
@@ -43,6 +46,15 @@ module Goo
         assert_invalid "user..user@example.com"
         assert_invalid "user@domain..com"
         assert_invalid "user@"
+        assert_invalid "user@example.xn--"
+        assert_invalid "user@example.-xn--p1ai"
+        assert_invalid "user@example.xn--p1ai-"
+      end
+
+      def test_non_ascii_email_addresses
+        assert_invalid "usér@example.com"
+        assert_invalid "user@exämple.com"
+        assert_invalid "用户@例子.公司"
       end
 
       def test_email_length_limits

--- a/test/test_email_validator.rb
+++ b/test/test_email_validator.rb
@@ -33,6 +33,14 @@ module Goo
         assert_valid "user@sub.domain.xn--p1ai"
       end
 
+      def test_case_insensitive_domains
+        # Domain names are case-insensitive (RFC 1035 §2.3.3); uppercase
+        # domains and punycode TLDs must validate the same as lowercase.
+        assert_valid "User@Example.COM"
+        assert_valid "user@EXAMPLE.COM"
+        assert_valid "user@example.XN--P1AI"
+      end
+
       def test_invalid_emails_structure
         assert_invalid ""
         assert_invalid "plainaddress"

--- a/test/test_validators.rb
+++ b/test/test_validators.rb
@@ -129,6 +129,12 @@ class TestValidators < MiniTest::Unit::TestCase
     p.username = "good.username"
     assert p.valid?
 
+    p.username = "admin"
+    assert p.valid?
+
+    p.username = "administrator"
+    assert p.valid?
+
     p.username = "bad-username"
     refute p.valid?
 
@@ -136,6 +142,18 @@ class TestValidators < MiniTest::Unit::TestCase
     refute p.valid?
 
     p.username = "badusername with spaces"
+    refute p.valid?
+
+    p.username = " goodusername"
+    refute p.valid?
+
+    p.username = "goodusername "
+    refute p.valid?
+
+    p.username = " goodusername "
+    refute p.valid?
+
+    p.username = "root"
     refute p.valid?
 
     p.username = "<input type=\"text\" value=\"jaVasCript:/*-/*`/*\\`/*'/*\"/**/(/* */oNcliCk=alert(1) )//%0D%0A%0d%0a//</stYle/</titLe/</teXtarEa/</scRipt/--!>\\x3csVg/<sVg/oNloAd=alert(2)//>\\x3e\"></input>"


### PR DESCRIPTION
  - allow punycode TLDs in the email validator
  - document and test that non-ASCII email addresses are not supported
  - reject usernames with leading or trailing whitespace
  - remove `admin` and `administrator` from the reserved username list
  - add regression coverage for the updated validator behavior