### PR TITLE
Feature: Add alias-backed Solr support for search indexing (ALT)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,6 @@ group :profiling do
   gem "thin"
 end
 
-gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'ontoportal-lirmm-development'
+gem 'sparql-client', github: 'ncbo/sparql-client', branch: 'development'
 gem "rdf-raptor", github: "ruby-rdf/rdf-raptor", ref: "6392ceabf71c3233b0f7f0172f662bd4a22cd534" # use version 3.3.0 when available
 gem 'net-ftp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 GIT
   remote: https://github.com/ncbo/sparql-client.git
   revision: 2ac20b217bb7ad2b11305befe0ee77d75e44eac5
-  branch: ontoportal-lirmm-development
+  branch: development
   specs:
     sparql-client (3.2.2)
       net-http-persistent (~> 4.0, >= 4.0.2)

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -42,6 +42,7 @@ module Goo
   @@search_backends = {}
   @@search_connection = {}
   @@search_collections = {}
+  @@reindex_connection = {}
   @@default_namespace = nil
   @@id_prefix = nil
   @@redis_client = nil
@@ -294,9 +295,10 @@ module Goo
     @@search_connection[collection_name]
   end
 
-  def self.add_search_connection(collection_name, search_backend = :main, &block)
+  def self.add_search_connection(collection_name, search_backend = :main, bootstrap_collection: nil, &block)
     @@search_collections[collection_name] = {
       search_backend: search_backend,
+      bootstrap_collection: bootstrap_collection,
       block: block_given? ? block : nil
     }
   end
@@ -305,7 +307,7 @@ module Goo
     @@search_connection
   end
 
-  def self.init_search_connection(collection_name, search_backend = :main,  block = nil, force: false)
+  def self.init_search_connection(collection_name, search_backend = :main, block = nil, bootstrap_collection: nil, force: false)
     return @@search_connection[collection_name] if @@search_connection[collection_name] && !force
 
     @@search_connection[collection_name] = SOLR::SolrConnector.new(search_conf(search_backend), collection_name)
@@ -313,17 +315,58 @@ module Goo
       block.call(@@search_connection[collection_name].schema_generator)
       @@search_connection[collection_name].enable_custom_schema
     end
-    @@search_connection[collection_name].init(force)
+    @@search_connection[collection_name].init(force: force, bootstrap_collection: bootstrap_collection)
     @@search_connection[collection_name]
   end
-
 
   def self.init_search_connections(force=false)
     @@search_collections.each do |collection_name, backend|
       search_backend = backend[:search_backend]
-      block =  backend[:block]
-      init_search_connection(collection_name, search_backend, block, force: force)
+      block = backend[:block]
+      bootstrap_collection = backend[:bootstrap_collection]
+      init_search_connection(collection_name, search_backend, block, bootstrap_collection: bootstrap_collection, force: force)
     end
+  end
+
+  # --- Re-index workflow ---
+
+  # Creates a new collection for re-indexing and returns a SolrConnector to it.
+  # The alias is NOT swapped — call complete_reindex after indexing is done.
+  def self.create_reindex_connection(alias_name, new_collection_name)
+    live_connector = @@search_connection[alias_name]
+    raise ArgumentError, "No live connection found for alias '#{alias_name}'" unless live_connector
+
+    live_connector.create_reindex_collection(new_collection_name)
+
+    # Create a SolrConnector that points directly at the new physical collection
+    backend_info = @@search_collections[alias_name]
+    search_backend = backend_info[:search_backend]
+    @@reindex_connection[alias_name] = SOLR::SolrConnector.new(search_conf(search_backend), new_collection_name)
+
+    # Schema is already initialized by create_reindex_collection,
+    # so skip init — just apply custom schema flag if needed
+    if backend_info[:block]
+      backend_info[:block].call(@@reindex_connection[alias_name].schema_generator)
+      @@reindex_connection[alias_name].enable_custom_schema
+    end
+
+    @@reindex_connection[alias_name]
+  end
+
+  # Returns the reindex SolrConnector for a given alias.
+  def self.reindex_client(alias_name)
+    @@reindex_connection[alias_name]
+  end
+
+  # Swaps the alias to the reindex collection and cleans up.
+  def self.complete_reindex(alias_name)
+    reindex_conn = @@reindex_connection[alias_name]
+    raise ArgumentError, "No reindex connection found for alias '#{alias_name}'" unless reindex_conn
+
+    live_connector = @@search_connection[alias_name]
+    live_connector.swap_alias_and_delete_old(reindex_conn.collection_name)
+
+    @@reindex_connection.delete(alias_name)
   end
 
   def self.sparql_query_client(name=:main)

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -358,7 +358,7 @@ module Goo
     @@reindex_connection[alias_name]
   end
 
-  # Swaps the alias to the reindex collection and cleans up.
+  # Swaps the alias to the reindex collection and cleans up (deletes old collection).
   def self.complete_reindex(alias_name)
     reindex_conn = @@reindex_connection[alias_name]
     raise ArgumentError, "No reindex connection found for alias '#{alias_name}'" unless reindex_conn
@@ -367,6 +367,15 @@ module Goo
     live_connector.swap_alias_and_delete_old(reindex_conn.collection_name)
 
     @@reindex_connection.delete(alias_name)
+  end
+
+  # Promotes an alias to point to an existing collection without deleting the old one.
+  # Does not require a prior create_reindex_connection call.
+  def self.promote_alias(alias_name, new_collection_name)
+    live_connector = @@search_connection[alias_name]
+    raise ArgumentError, "No live connection found for alias '#{alias_name}'" unless live_connector
+
+    live_connector.promote_alias(new_collection_name)
   end
 
   def self.sparql_query_client(name=:main)

--- a/lib/goo/search/search.rb
+++ b/lib/goo/search/search.rb
@@ -141,6 +141,11 @@ module Goo
         Goo.search_client(connection_name)
       end
 
+      # Returns the SolrConnector for the reindex collection (if one has been created).
+      def reindex_client
+        Goo.reindex_client(search_collection_name)
+      end
+
       def custom_schema?(connection_name = search_collection_name)
         search_client(connection_name)&.custom_schema?
       end

--- a/lib/goo/search/search.rb
+++ b/lib/goo/search/search.rb
@@ -119,14 +119,13 @@ module Goo
         !@model_settings[:search_collection].nil?
       end
 
-      def enable_indexing(collection_name, search_backend = :main, &block)
+      def enable_indexing(collection_name, search_backend = :main, bootstrap_collection: nil, &block)
         @model_settings[:search_collection] = collection_name
 
         if block_given?
-          # optional block to generate custom schema
-          Goo.add_search_connection(collection_name, search_backend, &block)
+          Goo.add_search_connection(collection_name, search_backend, bootstrap_collection: bootstrap_collection, &block)
         else
-          Goo.add_search_connection(collection_name, search_backend)
+          Goo.add_search_connection(collection_name, search_backend, bootstrap_collection: bootstrap_collection)
         end
 
         after_save :index

--- a/lib/goo/search/solr/solr_admin.rb
+++ b/lib/goo/search/solr/solr_admin.rb
@@ -74,6 +74,57 @@ module SOLR
     def collection_exists?(collection_name)
       fetch_all_collections.include?(collection_name.to_s)
     end
+
+    def list_aliases
+      aliases_url = URI.parse("#{admin_url}/collections?action=LISTALIASES")
+      http = Net::HTTP.new(aliases_url.host, aliases_url.port)
+      request = Net::HTTP::Get.new(aliases_url.request_uri)
+
+      begin
+        response = http.request(request)
+        raise StandardError, "Failed to fetch aliases. HTTP #{response.code}: #{response.message}" unless response.code.to_i == 200
+      rescue StandardError => e
+        raise StandardError, "Failed to fetch aliases. #{e.message}"
+      end
+
+      JSON.parse(response.body).fetch('aliases', {})
+    end
+
+    def alias_exists?(alias_name)
+      list_aliases.key?(alias_name.to_s)
+    end
+
+    def resolve_alias(alias_name)
+      list_aliases[alias_name.to_s]
+    end
+
+    def create_alias(alias_name, collection_name)
+      alias_url = URI.parse("#{admin_url}/collections?action=CREATEALIAS&name=#{alias_name}&collections=#{collection_name}")
+      http = Net::HTTP.new(alias_url.host, alias_url.port)
+      request = Net::HTTP::Post.new(alias_url.request_uri)
+
+      begin
+        response = http.request(request)
+        raise StandardError, "Failed to create alias. HTTP #{response.code}: #{response.message}" unless response.code.to_i == 200
+      rescue StandardError => e
+        raise StandardError, "Failed to create alias. #{e.message}"
+      end
+    end
+
+    def delete_alias(alias_name)
+      return unless alias_exists?(alias_name)
+
+      alias_url = URI.parse("#{admin_url}/collections?action=DELETEALIAS&name=#{alias_name}")
+      http = Net::HTTP.new(alias_url.host, alias_url.port)
+      request = Net::HTTP::Post.new(alias_url.request_uri)
+
+      begin
+        response = http.request(request)
+        raise StandardError, "Failed to delete alias. HTTP #{response.code}: #{response.message}" unless response.code.to_i == 200
+      rescue StandardError => e
+        raise StandardError, "Failed to delete alias. #{e.message}"
+      end
+    end
   end
 end
 

--- a/lib/goo/search/solr/solr_connector.rb
+++ b/lib/goo/search/solr/solr_connector.rb
@@ -67,10 +67,10 @@ module SOLR
       new_name
     end
 
-    # Atomically swaps the alias to point to a new collection and deletes the old one.
-    # Updates @collection_name to reflect the new target.
-    def swap_alias_and_delete_old(new_collection_name)
-      raise "Alias swap requires an aliased connector" unless aliased?
+    # Atomically swaps the alias to point to a new collection.
+    # Returns the old collection name. Updates @collection_name to reflect the new target.
+    def promote_alias(new_collection_name)
+      raise "Alias promotion requires an aliased connector" unless aliased?
 
       new_name = new_collection_name.to_s
       raise ArgumentError, "Collection '#{new_name}' does not exist" unless collection_exists?(new_name)
@@ -79,7 +79,14 @@ module SOLR
       create_alias(@alias_name.to_s, new_name)
       @collection_name = new_name
 
-      delete_collection(old_collection) if old_collection && old_collection != new_name
+      old_collection
+    end
+
+    # Atomically swaps the alias to point to a new collection and deletes the old one.
+    # Updates @collection_name to reflect the new target.
+    def swap_alias_and_delete_old(new_collection_name)
+      old_collection = promote_alias(new_collection_name)
+      delete_collection(old_collection) if old_collection && old_collection != @collection_name
     end
 
     private

--- a/lib/goo/search/solr/solr_connector.rb
+++ b/lib/goo/search/solr/solr_connector.rb
@@ -28,21 +28,90 @@ module SOLR
       @custom_schema = false
     end
 
-    def init(force = false)
-      if alias_exists?(@alias_name)
-        return unless force
+    def init(force: false, bootstrap_collection: nil)
+      bootstrap_name = (bootstrap_collection || @alias_name).to_s
 
-        # Alias exists — reinitialize schema on the underlying collection
-        @collection_name = resolve_alias(@alias_name)
-        init_schema
+      if uses_alias?(bootstrap_name)
+        init_with_alias(force: force, bootstrap_name: bootstrap_name)
       else
-        # First boot — create versioned collection + alias
-        versioned_name = "#{@alias_name}_v1"
-        create_collection(versioned_name)
-        @collection_name = versioned_name
-        init_schema
-        create_alias(@alias_name.to_s, versioned_name)
+        init_without_alias(force: force)
       end
+    end
+
+    # Returns true if this connector uses an alias (i.e. supports re-indexing).
+    def aliased?
+      @aliased
+    end
+
+    # Creates a new collection for re-indexing with the same schema as the current one.
+    # Does NOT swap the alias — call swap_alias_and_delete_old after indexing is complete.
+    def create_reindex_collection(new_collection_name)
+      raise "Re-indexing requires an aliased connector" unless aliased?
+      raise ArgumentError, "new_collection_name is required" unless new_collection_name && !new_collection_name.to_s.empty?
+
+      new_name = new_collection_name.to_s
+      raise ArgumentError, "Collection '#{new_name}' already exists" if collection_exists?(new_name)
+
+      create_collection(new_name)
+
+      # Apply the same schema to the new collection by temporarily
+      # pointing schema operations at it, then restoring
+      original_collection = @collection_name
+      @collection_name = new_name
+      begin
+        init_schema
+      ensure
+        @collection_name = original_collection
+      end
+
+      new_name
+    end
+
+    # Atomically swaps the alias to point to a new collection and deletes the old one.
+    # Updates @collection_name to reflect the new target.
+    def swap_alias_and_delete_old(new_collection_name)
+      raise "Alias swap requires an aliased connector" unless aliased?
+
+      new_name = new_collection_name.to_s
+      raise ArgumentError, "Collection '#{new_name}' does not exist" unless collection_exists?(new_name)
+
+      old_collection = resolve_alias(@alias_name.to_s)
+      create_alias(@alias_name.to_s, new_name)
+      @collection_name = new_name
+
+      delete_collection(old_collection) if old_collection && old_collection != new_name
+    end
+
+    private
+
+    # An alias is used when the bootstrap collection name differs from the alias name.
+    def uses_alias?(bootstrap_name)
+      bootstrap_name.to_s != @alias_name.to_s
+    end
+
+    # Init for connectors that use an alias (re-index capable).
+    def init_with_alias(force: false, bootstrap_name:)
+      @aliased = true
+
+      if alias_exists?(@alias_name)
+        @collection_name = resolve_alias(@alias_name)
+        init_schema if force
+      else
+        create_collection(bootstrap_name)
+        @collection_name = bootstrap_name
+        init_schema
+        create_alias(@alias_name.to_s, bootstrap_name)
+      end
+    end
+
+    # Init for connectors without an alias (simple collection, no re-index support).
+    def init_without_alias(force: false)
+      @aliased = false
+
+      return if collection_exists?(@collection_name) && !force
+
+      create_collection
+      init_schema
     end
 
   end

--- a/lib/goo/search/solr/solr_connector.rb
+++ b/lib/goo/search/solr/solr_connector.rb
@@ -8,11 +8,12 @@ module SOLR
 
   class SolrConnector
     include Schema, Administration, Query
-    attr_reader :solr
+    attr_reader :solr, :collection_name, :alias_name
 
     def initialize(solr_url, collection_name)
       @solr_url = solr_url
       @collection_name = collection_name
+      @alias_name = collection_name
       @solr = RSolr.connect(url: collection_url)
 
       # Perform a status test and wait up to 30 seconds before raising an error
@@ -24,16 +25,24 @@ module SOLR
       end
       raise "Solr instance not reachable within #{max_wait_time} seconds" unless solr_alive?
 
-
       @custom_schema = false
     end
 
     def init(force = false)
-      return if collection_exists?(@collection_name) && !force
+      if alias_exists?(@alias_name)
+        return unless force
 
-      create_collection
-
-      init_schema
+        # Alias exists — reinitialize schema on the underlying collection
+        @collection_name = resolve_alias(@alias_name)
+        init_schema
+      else
+        # First boot — create versioned collection + alias
+        versioned_name = "#{@alias_name}_v1"
+        create_collection(versioned_name)
+        @collection_name = versioned_name
+        init_schema
+        create_alias(@alias_name.to_s, versioned_name)
+      end
     end
 
   end

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -5,12 +5,14 @@ require 'benchmark'
 class TestSolr < MiniTest::Unit::TestCase
   def self.before_suite
     @@connector = SOLR::SolrConnector.new(Goo.search_conf, 'test')
-    @@connector.delete_collection('test')
+    @@connector.delete_alias('test')
+    @@connector.delete_collection('test_v1')
     @@connector.init
   end
 
   def self.after_suite
-    @@connector.delete_collection('test')
+    @@connector.delete_alias('test')
+    @@connector.delete_collection('test_v1')
   end
 
   def test_add_collection
@@ -111,17 +113,39 @@ class TestSolr < MiniTest::Unit::TestCase
     assert_nil field
   end
 
+  def test_alias_aware_init
+    connector = @@connector
+
+    # init should have created a versioned collection and an alias
+    assert connector.collection_exists?('test_v1'), 'Expected test_v1 collection to exist'
+    assert connector.alias_exists?('test'), 'Expected test alias to exist'
+    assert_equal 'test_v1', connector.resolve_alias('test')
+    assert_equal 'test', connector.alias_name
+    assert_equal 'test_v1', connector.collection_name
+  end
+
+  def test_alias_aware_init_skips_when_alias_exists
+    # Create a fresh connector with the same alias name
+    connector2 = SOLR::SolrConnector.new(Goo.search_conf, 'test')
+    connector2.init
+
+    # Should reuse existing alias and collection, not create test_v1 again
+    assert connector2.alias_exists?('test')
+    assert_equal 'test_v1', connector2.resolve_alias('test')
+    assert_equal 'test_v1', connector2.collection_name
+  end
+
   def test_list_aliases
     connector = @@connector
     # Clean up in case of prior failed run
     connector.delete_alias('test_alias')
 
     aliases_before = connector.list_aliases
-    connector.create_alias('test_alias', 'test')
+    connector.create_alias('test_alias', 'test_v1')
     aliases_after = connector.list_aliases
 
     assert_equal aliases_after.size, aliases_before.size + 1
-    assert_equal 'test', aliases_after['test_alias']
+    assert_equal 'test_v1', aliases_after['test_alias']
 
     connector.delete_alias('test_alias')
   end
@@ -132,7 +156,7 @@ class TestSolr < MiniTest::Unit::TestCase
 
     refute connector.alias_exists?('test_alias')
 
-    connector.create_alias('test_alias', 'test')
+    connector.create_alias('test_alias', 'test_v1')
     assert connector.alias_exists?('test_alias')
 
     connector.delete_alias('test_alias')
@@ -144,8 +168,8 @@ class TestSolr < MiniTest::Unit::TestCase
 
     assert_nil connector.resolve_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test')
-    assert_equal 'test', connector.resolve_alias('test_alias')
+    connector.create_alias('test_alias', 'test_v1')
+    assert_equal 'test_v1', connector.resolve_alias('test_alias')
 
     connector.delete_alias('test_alias')
   end
@@ -154,9 +178,9 @@ class TestSolr < MiniTest::Unit::TestCase
     connector = @@connector
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test')
+    connector.create_alias('test_alias', 'test_v1')
     assert connector.alias_exists?('test_alias')
-    assert_equal 'test', connector.resolve_alias('test_alias')
+    assert_equal 'test_v1', connector.resolve_alias('test_alias')
 
     connector.delete_alias('test_alias')
   end
@@ -166,8 +190,8 @@ class TestSolr < MiniTest::Unit::TestCase
     connector.create_collection('test3')
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test')
-    assert_equal 'test', connector.resolve_alias('test_alias')
+    connector.create_alias('test_alias', 'test_v1')
+    assert_equal 'test_v1', connector.resolve_alias('test_alias')
 
     # CREATEALIAS overwrites atomically — this is the swap mechanism
     connector.create_alias('test_alias', 'test3')
@@ -181,7 +205,7 @@ class TestSolr < MiniTest::Unit::TestCase
     connector = @@connector
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test')
+    connector.create_alias('test_alias', 'test_v1')
     assert connector.alias_exists?('test_alias')
 
     connector.delete_alias('test_alias')

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -111,6 +111,90 @@ class TestSolr < MiniTest::Unit::TestCase
     assert_nil field
   end
 
+  def test_list_aliases
+    connector = @@connector
+    # Clean up in case of prior failed run
+    connector.delete_alias('test_alias')
+
+    aliases_before = connector.list_aliases
+    connector.create_alias('test_alias', 'test')
+    aliases_after = connector.list_aliases
+
+    assert_equal aliases_after.size, aliases_before.size + 1
+    assert_equal 'test', aliases_after['test_alias']
+
+    connector.delete_alias('test_alias')
+  end
+
+  def test_alias_exists
+    connector = @@connector
+    connector.delete_alias('test_alias')
+
+    refute connector.alias_exists?('test_alias')
+
+    connector.create_alias('test_alias', 'test')
+    assert connector.alias_exists?('test_alias')
+
+    connector.delete_alias('test_alias')
+  end
+
+  def test_resolve_alias
+    connector = @@connector
+    connector.delete_alias('test_alias')
+
+    assert_nil connector.resolve_alias('test_alias')
+
+    connector.create_alias('test_alias', 'test')
+    assert_equal 'test', connector.resolve_alias('test_alias')
+
+    connector.delete_alias('test_alias')
+  end
+
+  def test_create_alias
+    connector = @@connector
+    connector.delete_alias('test_alias')
+
+    connector.create_alias('test_alias', 'test')
+    assert connector.alias_exists?('test_alias')
+    assert_equal 'test', connector.resolve_alias('test_alias')
+
+    connector.delete_alias('test_alias')
+  end
+
+  def test_create_alias_overwrites_existing
+    connector = @@connector
+    connector.create_collection('test3')
+    connector.delete_alias('test_alias')
+
+    connector.create_alias('test_alias', 'test')
+    assert_equal 'test', connector.resolve_alias('test_alias')
+
+    # CREATEALIAS overwrites atomically — this is the swap mechanism
+    connector.create_alias('test_alias', 'test3')
+    assert_equal 'test3', connector.resolve_alias('test_alias')
+
+    connector.delete_alias('test_alias')
+    connector.delete_collection('test3')
+  end
+
+  def test_delete_alias
+    connector = @@connector
+    connector.delete_alias('test_alias')
+
+    connector.create_alias('test_alias', 'test')
+    assert connector.alias_exists?('test_alias')
+
+    connector.delete_alias('test_alias')
+    refute connector.alias_exists?('test_alias')
+  end
+
+  def test_delete_alias_nonexistent_is_noop
+    connector = @@connector
+    connector.delete_alias('nonexistent_alias')
+    # Should not raise — just returns silently
+    refute connector.alias_exists?('nonexistent_alias')
+  end
+
   private
 
   def add_field(name, connector)

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -3,16 +3,20 @@ require 'benchmark'
 
 
 class TestSolr < MiniTest::Unit::TestCase
+  BOOTSTRAP_COLLECTION = 'test_bootstrap'
+
   def self.before_suite
     @@connector = SOLR::SolrConnector.new(Goo.search_conf, 'test')
     @@connector.delete_alias('test')
-    @@connector.delete_collection('test_v1')
-    @@connector.init
+    @@connector.delete_collection(BOOTSTRAP_COLLECTION)
+    @@connector.delete_collection('test_reindex')
+    @@connector.init(bootstrap_collection: BOOTSTRAP_COLLECTION)
   end
 
   def self.after_suite
     @@connector.delete_alias('test')
-    @@connector.delete_collection('test_v1')
+    @@connector.delete_collection(BOOTSTRAP_COLLECTION)
+    @@connector.delete_collection('test_reindex')
   end
 
   def test_add_collection
@@ -116,23 +120,38 @@ class TestSolr < MiniTest::Unit::TestCase
   def test_alias_aware_init
     connector = @@connector
 
-    # init should have created a versioned collection and an alias
-    assert connector.collection_exists?('test_v1'), 'Expected test_v1 collection to exist'
+    # init should have created the bootstrap collection and an alias
+    assert connector.collection_exists?(BOOTSTRAP_COLLECTION), "Expected #{BOOTSTRAP_COLLECTION} collection to exist"
     assert connector.alias_exists?('test'), 'Expected test alias to exist'
-    assert_equal 'test_v1', connector.resolve_alias('test')
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test')
     assert_equal 'test', connector.alias_name
-    assert_equal 'test_v1', connector.collection_name
+    assert_equal BOOTSTRAP_COLLECTION, connector.collection_name
+    assert connector.aliased?, 'Connector should be in aliased mode'
   end
 
   def test_alias_aware_init_skips_when_alias_exists
     # Create a fresh connector with the same alias name
     connector2 = SOLR::SolrConnector.new(Goo.search_conf, 'test')
+    connector2.init(bootstrap_collection: 'should_not_be_created')
+
+    # Should reuse existing alias and collection, not create a new one
+    assert connector2.alias_exists?('test')
+    assert_equal BOOTSTRAP_COLLECTION, connector2.resolve_alias('test')
+    assert_equal BOOTSTRAP_COLLECTION, connector2.collection_name
+    refute connector2.collection_exists?('should_not_be_created')
+  end
+
+  def test_init_without_bootstrap_creates_plain_collection
+    # When no bootstrap_collection is given, alias_name == bootstrap_name,
+    # so it creates a plain collection (no alias)
+    connector2 = SOLR::SolrConnector.new(Goo.search_conf, 'test_plain')
     connector2.init
 
-    # Should reuse existing alias and collection, not create test_v1 again
-    assert connector2.alias_exists?('test')
-    assert_equal 'test_v1', connector2.resolve_alias('test')
-    assert_equal 'test_v1', connector2.collection_name
+    assert connector2.collection_exists?('test_plain')
+    refute connector2.alias_exists?('test_plain'), 'Should not create an alias when names match'
+    refute connector2.aliased?, 'Connector should not be in aliased mode'
+
+    connector2.delete_collection('test_plain')
   end
 
   def test_list_aliases
@@ -141,11 +160,11 @@ class TestSolr < MiniTest::Unit::TestCase
     connector.delete_alias('test_alias')
 
     aliases_before = connector.list_aliases
-    connector.create_alias('test_alias', 'test_v1')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
     aliases_after = connector.list_aliases
 
     assert_equal aliases_after.size, aliases_before.size + 1
-    assert_equal 'test_v1', aliases_after['test_alias']
+    assert_equal BOOTSTRAP_COLLECTION, aliases_after['test_alias']
 
     connector.delete_alias('test_alias')
   end
@@ -156,7 +175,7 @@ class TestSolr < MiniTest::Unit::TestCase
 
     refute connector.alias_exists?('test_alias')
 
-    connector.create_alias('test_alias', 'test_v1')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
     assert connector.alias_exists?('test_alias')
 
     connector.delete_alias('test_alias')
@@ -168,8 +187,8 @@ class TestSolr < MiniTest::Unit::TestCase
 
     assert_nil connector.resolve_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test_v1')
-    assert_equal 'test_v1', connector.resolve_alias('test_alias')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test_alias')
 
     connector.delete_alias('test_alias')
   end
@@ -178,9 +197,9 @@ class TestSolr < MiniTest::Unit::TestCase
     connector = @@connector
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test_v1')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
     assert connector.alias_exists?('test_alias')
-    assert_equal 'test_v1', connector.resolve_alias('test_alias')
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test_alias')
 
     connector.delete_alias('test_alias')
   end
@@ -190,8 +209,8 @@ class TestSolr < MiniTest::Unit::TestCase
     connector.create_collection('test3')
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test_v1')
-    assert_equal 'test_v1', connector.resolve_alias('test_alias')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test_alias')
 
     # CREATEALIAS overwrites atomically — this is the swap mechanism
     connector.create_alias('test_alias', 'test3')
@@ -205,7 +224,7 @@ class TestSolr < MiniTest::Unit::TestCase
     connector = @@connector
     connector.delete_alias('test_alias')
 
-    connector.create_alias('test_alias', 'test_v1')
+    connector.create_alias('test_alias', BOOTSTRAP_COLLECTION)
     assert connector.alias_exists?('test_alias')
 
     connector.delete_alias('test_alias')
@@ -217,6 +236,66 @@ class TestSolr < MiniTest::Unit::TestCase
     connector.delete_alias('nonexistent_alias')
     # Should not raise — just returns silently
     refute connector.alias_exists?('nonexistent_alias')
+  end
+
+  def test_create_reindex_collection
+    connector = @@connector
+
+    new_name = connector.create_reindex_collection('test_reindex')
+    assert_equal 'test_reindex', new_name
+    assert connector.collection_exists?('test_reindex')
+
+    # Alias should still point to the bootstrap collection
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test')
+    assert_equal BOOTSTRAP_COLLECTION, connector.collection_name
+
+    connector.delete_collection('test_reindex')
+  end
+
+  def test_create_reindex_collection_requires_name
+    connector = @@connector
+
+    assert_raises(ArgumentError) { connector.create_reindex_collection(nil) }
+    assert_raises(ArgumentError) { connector.create_reindex_collection('') }
+  end
+
+  def test_reindex_not_available_without_alias
+    plain_connector = SOLR::SolrConnector.new(Goo.search_conf, 'test_plain2')
+    plain_connector.init
+
+    assert_raises(RuntimeError) { plain_connector.create_reindex_collection('some_name') }
+    assert_raises(RuntimeError) { plain_connector.swap_alias_and_delete_old('some_name') }
+
+    plain_connector.delete_collection('test_plain2')
+  end
+
+  def test_create_reindex_collection_rejects_existing
+    connector = @@connector
+
+    assert_raises(ArgumentError) do
+      connector.create_reindex_collection(BOOTSTRAP_COLLECTION)
+    end
+  end
+
+  def test_swap_alias_and_delete_old
+    connector = @@connector
+
+    # Create a reindex collection
+    connector.create_reindex_collection('test_reindex')
+    assert connector.collection_exists?('test_reindex')
+    assert connector.collection_exists?(BOOTSTRAP_COLLECTION)
+
+    # Swap alias and delete old
+    connector.swap_alias_and_delete_old('test_reindex')
+
+    assert_equal 'test_reindex', connector.resolve_alias('test')
+    assert_equal 'test_reindex', connector.collection_name
+    refute connector.collection_exists?(BOOTSTRAP_COLLECTION), 'Old collection should have been deleted'
+
+    # Restore state for other tests: create bootstrap again and swap back
+    connector.create_reindex_collection(BOOTSTRAP_COLLECTION)
+    connector.swap_alias_and_delete_old(BOOTSTRAP_COLLECTION)
+    assert_equal BOOTSTRAP_COLLECTION, connector.resolve_alias('test')
   end
 
   private


### PR DESCRIPTION
## Summary

Adds SolrCloud alias support to Goo, enabling zero-downtime full re-indexing of ontology search collections.

After migrating from static Solr XML schemas to dynamic SolrCloud, the ability to index into an alternate core and swap was lost. This PR restores that capability using SolrCloud aliases: models reference alias names, aliases point to versioned physical collections, and atomic alias swaps (`CREATEALIAS`) enable zero-downtime re-indexing.

### Key changes

- **Alias CRUD** (`solr_admin.rb`): `list_aliases`, `alias_exists?`, `resolve_alias`, `create_alias`, `delete_alias` — all via SolrCloud Collections API
- **Two-mode connector** (`solr_connector.rb`): `init()` accepts a `bootstrap_collection:` parameter. When the bootstrap name differs from the alias name → aliased mode (alias + physical collection, re-index capable). When same or nil → plain collection mode (no alias, backward-compatible for collections like `:ontology_metadata`)
- **Re-index workflow** (`solr_connector.rb` + `goo.rb`):
  - `create_reindex_collection(name)` — creates a new collection with the correct schema
  - `promote_alias(name)` — atomically swaps the alias, keeps the old collection (for rollback)
  - `swap_alias_and_delete_old(name)` — swaps and deletes the old collection
  - `Goo.create_reindex_connection`, `Goo.reindex_client`, `Goo.complete_reindex`, `Goo.promote_alias` — module-level API
- **DSL passthrough** (`search.rb`): `enable_indexing` now accepts and forwards `bootstrap_collection:` to the connector
- **Tests** (`test_solr.rb`): Full coverage for alias-aware init, plain collection init, reindex collection creation, alias swap, promote, and cleanup

### How it works

```
# Aliased mode (term_search, prop_search):
enable_indexing(:term_search, :main, bootstrap_collection: :term_search_bootstrap)
# First boot: creates collection "term_search_bootstrap", creates alias "term_search" → "term_search_bootstrap"
# Subsequent boots: resolves alias, uses existing collection
# Re-index: create new collection → index into it → promote alias → optionally delete old

# Plain mode (ontology_metadata):
enable_indexing(:ontology_metadata)
# Creates collection "ontology_metadata" directly, no alias
```

## Test plan

- [ ] `bundle exec ruby -Itest test/solr/test_solr.rb` — alias lifecycle, reindex, promote, plain mode
- [ ] Verify existing `test/test_search.rb` tests still pass
- [ ] End-to-end: boot with aliased connectors, confirm alias creation in Solr Admin UI
- [ ] End-to-end: create reindex collection, index data, promote alias, verify search resolves through new collection