### PR TITLE
fix: stop mutating @include in process_query_init

### DIFF
--- a/lib/goo/sparql/processor.rb
+++ b/lib/goo/sparql/processor.rb
@@ -18,12 +18,12 @@ module Goo
           return @result
         end
 
-        @include << @include_embed if @include_embed.length > 0
+        effective_include = @include_embed.empty? ? @include : @include + [@include_embed]
 
         @predicates = unmmaped_predicates()
         @equivalent_predicates = retrieve_equivalent_predicates()
 
-        options_load = { models: @models, include: @include, ids: @ids,
+        options_load = { models: @models, include: effective_include, ids: @ids,
                          graph_match: @pattern, klass: @klass,
                          filters: @filters, order_by: @order_by ,
                          read_only: @read_only, rules: @rules,
@@ -45,7 +45,7 @@ module Goo
         if @page_i && !use_redis_index?
           page_options = options_load.dup
           page_options.delete(:include)
-          page_options[:include_pagination] = @include
+          page_options[:include_pagination] = effective_include
           page_options[:query_options] = @query_options
 
           @count = run_count_query(page_options)

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -284,6 +284,36 @@ class TestWhere < MiniTest::Unit::TestCase
     assert_equal total_count, page_1.size + page_2.size
   end
 
+  def test_paged_where_with_embed_include_is_reusable
+    # Force the sliced load path — otherwise get_includes' delete_if
+    # strips the embed hash from @include and hides the accumulation across pages.
+    original_slice = Goo.slice_loading_size
+    Goo.slice_loading_size = 1
+    begin
+      page_size = 2
+      paging = Student.where.include(:name, :birth_date, enrolled: [:name]).page(1, page_size)
+
+      page_1 = paging.page(1, page_size).all
+      refute_empty page_1, 'page 1 should return students'
+
+      page_2 = nil
+      begin
+        page_2 = paging.page(2, page_size).all
+      rescue ArgumentError => e
+        flunk "reusing Where across pages should not raise (got: #{e.message})"
+      end
+
+      refute_empty page_2, 'page 2 should return more students'
+
+      (page_1 + page_2).each do |student|
+        assert_instance_of String, student.name
+        student.enrolled
+      end
+    ensure
+      Goo.slice_loading_size = original_slice
+    end
+  end
+
   def test_two_level_include
     programs = Program.where.include(:name).all
     r = Program.where.models(programs).include(students: [:name]).all


### PR DESCRIPTION
Fixes ncbo/goo#181.

## Summary
- Reused `Where` objects with an embed-include raised `ArgumentError: Not supported case for embed` on the second `.all` call whenever the load entered the slicing branch (models per page > `Goo.slice_loading_size`).
- Root cause: `@include` was mutated in place on every call at `processor.rb:21`. The unsliced path's `delete_if` cleanup masked this, but the sliced path `dup`s the include array per slice, so `@include` accumulated duplicate embed hashes across pages until `get_embed_includes` raised.
- Fix: build a per-call `effective_include` local; leave `@include` / `@include_embed` untouched. Three lines changed.
- Added regression test `test_paged_where_with_embed_include_is_reusable` that forces slicing via `Goo.slice_loading_size = 1`. Fails on `development` with the production error, passes with the fix applied.

See ncbo/goo#181 for full trigger analysis and blast radius.