### PR TITLE
Fix: prevent Solr initialization from clearing index data

### DIFF
--- a/lib/goo/search/solr/solr_connector.rb
+++ b/lib/goo/search/solr/solr_connector.rb
@@ -33,34 +33,34 @@ module SOLR
 
     alias physical_collection_name collection_name
 
-    def init(force = false, bootstrap_collection: nil)
+    def init(force = false, bootstrap_collection: nil, clear_data: false)
       bootstrap_collection ||= @collection_name
-      return init_with_alias(bootstrap_collection, force: force) if uses_alias?(bootstrap_collection)
+      return init_with_alias(bootstrap_collection, force: force, clear_data: clear_data) if uses_alias?(bootstrap_collection)
 
-      init_without_alias(force)
+      init_without_alias(force, clear_data: clear_data)
     end
 
-    def init_without_alias(force = false)
+    def init_without_alias(force = false, clear_data: false)
       @aliased = false
       return if collection_exists?(@collection_name) && !force
 
       create_collection(@collection_name, @num_shards, @replication_factor)
 
-      init_schema
+      init_schema(clear_data: clear_data)
     end
 
-    def init_with_alias(bootstrap_collection, force: false)
+    def init_with_alias(bootstrap_collection, force: false, clear_data: false)
       @aliased = true
 
       if alias_exists?(@alias_name)
         with_collection(resolve_alias(@alias_name).first) do
-          init_schema if force
+          init_schema(clear_data: clear_data) if force
         end
       else
         with_collection(bootstrap_collection) do
           bootstrap_exists = collection_exists?(@collection_name)
           create_collection(@collection_name, @num_shards, @replication_factor)
-          init_schema if force || !bootstrap_exists
+          init_schema(clear_data: clear_data) if force || !bootstrap_exists
           create_or_update_alias(@alias_name, bootstrap_collection)
         end
       end
@@ -100,6 +100,10 @@ module SOLR
       old_collection = promote_alias(new_collection_name, alias_name: alias_name)
       delete_collection(old_collection) if old_collection && old_collection != new_collection_name.to_s
       old_collection
+    end
+
+    def reset_schema!
+      init_schema(clear_data: true)
     end
 
     private

--- a/lib/goo/search/solr/solr_schema.rb
+++ b/lib/goo/search/solr/solr_schema.rb
@@ -69,8 +69,8 @@ module SOLR
       end
     end
 
-    def init_schema(generator = schema_generator)
-      clear_all_data
+    def init_schema(generator = schema_generator, clear_data: false)
+      clear_all_data if clear_data
       clear_all_schema(generator)
       fetch_schema
       default_fields = all_fields.map { |f| f['name'] }

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -73,6 +73,21 @@ class TestSolr < MiniTest::Unit::TestCase
     connector.delete_collection('test_reindex')
   end
 
+  def test_force_init_preserves_existing_documents
+    connector = @@connector
+    connector.clear_all_data
+    connector.index_document([{ id: 'force-init-preserves-data',
+                                resource_model: 'test',
+                                resource_id: 'force-init-preserves-data' }])
+
+    connector.init(true)
+
+    response = connector.search('*:*', rows: 0)
+    assert_equal 1, response['response']['numFound']
+  ensure
+    connector.clear_all_data if connector
+  end
+
   def test_missing_alias_uses_existing_bootstrap_without_reinitializing_schema
     connector = @@connector
     alias_name = 'test_alias'


### PR DESCRIPTION
## Summary

Prevent Solr connector initialization from clearing existing index documents as a side effect of `force: true`.

## Changes

- Update Solr schema initialization so it does not clear index data by default
- Add an explicit destructive schema reset path via `reset_schema!`
- Preserve existing documents when `SolrConnector#init(true)` is called
- Add regression coverage proving forced initialization does not delete indexed documents

## Why

`force: true` was used by callers to refresh/reinitialize Solr connections and schema state. Before this change, that path called `init_schema`, which unconditionally cleared all documents from the resolved Solr collection.

For alias-backed search collections, this could wipe the physical collection behind an alias during routine indexing workflows.

## Verification

Added regression coverage in `test/solr/test_solr.rb`:

- `test_force_init_preserves_existing_documents` indexes a document, calls `SolrConnector#init(true)`, and asserts the document remains in the collection.

Targeted test run:

```bash
bundle exec rake test TEST="./test/solr/test_solr.rb" TESTOPTS="--verbose --name=test_force_init_preserves_existing_documents"