### PR TITLE
chore: upgrade minitest 4.7.5 -> 6 (idiomatic hooks)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ gem "uuid"
 gem "request_store"
 
 group :test do
-  gem "minitest", '< 5.0'
+  gem "minitest", '~> 6.0'
+  gem "minitest-hooks" # before_all/after_all (per-suite once) hooks
   gem "pry"
   gem 'simplecov'
   gem 'simplecov-cobertura' # for submitting code coverage results to codecov.io

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,12 +43,19 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.13)
-      i18n (~> 0.6, >= 0.6.9)
-      minitest (~> 4.2)
-      multi_json (~> 1.3)
-      thread_safe (~> 0.1)
-      tzinfo (~> 0.3.37)
+    activesupport (8.1.3)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
     base64 (0.3.0)
@@ -62,6 +69,7 @@ GEM
     date (3.5.1)
     docile (1.4.1)
     domain_name (0.6.20240107)
+    drb (2.2.3)
     eventmachine (1.2.7)
     faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
@@ -78,7 +86,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.0)
       domain_name (~> 0.5)
-    i18n (0.9.5)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     json (2.19.1)
@@ -91,8 +99,11 @@ GEM
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2026.0303)
-    minitest (4.7.5)
-    multi_json (1.19.1)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
+    minitest-hooks (1.5.4)
+      minitest (> 5.3)
     mustermann (3.0.4)
       ruby2_keywords (~> 0.0.1)
     net-ftp (0.3.9)
@@ -106,6 +117,7 @@ GEM
       timeout
     netrc (0.11.0)
     ostruct (0.6.3)
+    prism (1.9.0)
     pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -161,6 +173,7 @@ GEM
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
     ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -183,12 +196,12 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       logger
       rack (>= 1, < 4)
-    thread_safe (0.3.6)
     tilt (2.7.0)
     time (0.4.2)
       date
     timeout (0.6.1)
-    tzinfo (0.3.62)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     uri (1.1.1)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -203,7 +216,8 @@ PLATFORMS
 DEPENDENCIES
   activesupport
   goo!
-  minitest (< 5.0)
+  minitest (~> 6.0)
+  minitest-hooks
   net-ftp
   ontoportal_testkit!
   pry

--- a/lib/goo/base/settings/settings.rb
+++ b/lib/goo/base/settings/settings.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/string'
+require 'active_support/core_ext/object/blank' # blank?/present? — no longer pulled in transitively by core_ext/string in activesupport 8
 require_relative 'yaml_settings'
 require_relative 'hooks'
 require_relative 'attribute'

--- a/test/settings/test_hooks.rb
+++ b/test/settings/test_hooks.rb
@@ -24,7 +24,7 @@ class TestHookModel < Goo::Base::Resource
 
 end
 
-class TestHooksSetting < MiniTest::Unit::TestCase
+class TestHooksSetting < Goo::TestCase
 
   def test_model_hooks
     TestHookModel.find("test").first&.delete

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -2,7 +2,7 @@ require_relative '../test_case'
 require 'benchmark'
 
 
-class TestSolr < MiniTest::Unit::TestCase
+class TestSolr < Goo::TestCase
   ALIAS_GUARD_FIXTURES = %w[
     test_shadow_target
     test_shadow_bootstrap
@@ -12,7 +12,7 @@ class TestSolr < MiniTest::Unit::TestCase
     test_fresh_alias_bootstrap
   ].freeze
 
-  def self.before_suite
+  def before_all
     @@connector = SOLR::SolrConnector.new(Goo.search_conf, 'test')
     @@connector.delete_alias('test_alias')
     @@connector.delete_collection('test')
@@ -28,7 +28,7 @@ class TestSolr < MiniTest::Unit::TestCase
     @@connector.init
   end
 
-  def self.after_suite
+  def after_all
     @@connector.delete_alias('test_alias')
     @@connector.delete_collection('test')
     @@connector.delete_collection('test2')

--- a/test/test_basic_persistence.rb
+++ b/test/test_basic_persistence.rb
@@ -53,7 +53,7 @@ class PersonPersistent < Goo::Base::Resource
   end
 end
 
-class TestBasicPersistence < MiniTest::Unit::TestCase
+class TestBasicPersistence < Goo::TestCase
   def initialize(*args)
     super(*args)
   end
@@ -179,7 +179,10 @@ class TestBasicPersistence < MiniTest::Unit::TestCase
     assert (!st_from_backend.modified?)
 
     st.class.attributes.each do |attr|
-      assert_equal(st.send("#{attr}"), st_from_backend.send("#{attr}"))
+      expected = st.send("#{attr}")
+      actual = st_from_backend.send("#{attr}")
+      # minitest 6 rejects assert_equal(nil, ...); branch so a nil expected value still compares
+      expected.nil? ? assert_nil(actual) : assert_equal(expected, actual)
     end
     assert st_from_backend.fully_loaded?
     assert (st_from_backend.missing_load_attributes.length == 0)
@@ -299,12 +302,12 @@ class TestBasicPersistence < MiniTest::Unit::TestCase
     assert person.persistent?
     assert !person.modified?
 
-    assert_equal nil, person.friends
+    assert_nil person.friends
 
     #default st and created
     assert_instance_of(StatusPersistent, person.status)
     assert_instance_of(DateTime, person.created)
-    assert_equal(nil, person.friends)
+    assert_nil person.friends
 
     person_from_backend = PersonPersistent.find("John").include(PersonPersistent.attributes).first
     assert_equal(person.status.id, person_from_backend.status.id)

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -1,13 +1,13 @@
 require_relative 'test_case'
 require_relative 'models'
 
-class TestCache < MiniTest::Unit::TestCase
+class TestCache < Goo::TestCase
 
   def initialize(*args)
     super(*args)
   end
 
-  def self.before_suite
+  def before_all
     begin
       Goo.use_cache=false
       GooTestData.create_test_case_data
@@ -21,7 +21,7 @@ class TestCache < MiniTest::Unit::TestCase
     end
   end
 
-  def self.after_suite
+  def after_all
     Goo.use_cache=false
     GooTestData.delete_test_case_data
   end

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -16,8 +16,8 @@ if ENV["COVERAGE"] == "true" || ENV["CI"] == "true"
   end
 end
 
-require 'minitest/unit'
-MiniTest::Unit.autorun
+require 'minitest/autorun'
+require 'minitest/hooks/test' # before_all/after_all: per-suite (once) setup/teardown
 
 require_relative "../lib/goo.rb"
 require_relative '../config/config.test'
@@ -83,6 +83,22 @@ end
 
 TestSafety.ensure_safe_test_targets!
 
+# Base class for goo's tests. Includes Minitest::Hooks so suites can define
+# before_all/after_all (run once per suite) — the idiomatic replacement for the
+# old GooTest::Unit#_run_suite before_suite/after_suite.
+module Goo
+  class TestCase < Minitest::Test
+    include Minitest::Hooks
+  end
+end
+
+# Minitest has no "before all suites" hook. Run-wide setup goes at load time
+# here (this file is required before autorun's at_exit fires); run-wide teardown
+# / reporting goes in Minitest.after_run. When feature/sparql-query-logging
+# rebases onto this, its run-total reporting lands here, e.g.:
+#   Goo.enable_query_count_total                       # before all suites
+#   Minitest.after_run { warn "[goo] SPARQL ..." }     # after all suites
+
 module TestHelpers
   def self.test_reset
     TestSafety.ensure_safe_test_targets!
@@ -98,41 +114,6 @@ module TestHelpers
 end
 
 class GooTest
-
-  class Unit < MiniTest::Unit
-
-    def before_suites
-    end
-
-    def after_suites
-    end
-
-    def _run_suites(suites, type)
-      begin
-        before_suites
-        super(suites, type)
-      ensure
-        after_suites
-      end
-    end
-
-    def _run_suite(suite, type)
-      ret = []
-      [Goo.slice_loading_size].each do |slice_size|
-        puts "\nrunning test with slice_loading_size=#{slice_size}"
-        Goo.slice_loading_size=slice_size
-        begin
-          suite.before_suite if suite.respond_to?(:before_suite)
-          ret += super(suite, type)
-        ensure
-          suite.after_suite if suite.respond_to?(:after_suite)
-        end
-      end
-      return ret
-    end
-  end
-
-  MiniTest::Unit.runner = GooTest::Unit.new
 
   def self.triples_for_subject(resource_id)
     rs = Goo.sparql_query_client.query("SELECT * WHERE { #{resource_id.to_ntriples} ?p ?o . }")

--- a/test/test_chunks_write.rb
+++ b/test/test_chunks_write.rb
@@ -5,18 +5,18 @@ module TestChunkWrite
   ONT_ID_EXTRA = "http://example.org/data/nemo/extra"
   ONT_ID_TURTLE = "http://example.org/data/omim_turtle_chunk_test"
 
-  class TestChunkWrite < MiniTest::Unit::TestCase
+  class TestChunkWrite < Goo::TestCase
 
     def initialize(*args)
       super(*args)
     end
 
-    def self.before_suite
-      _delete
+    def before_all
+      self.class._delete
     end
 
-    def self.after_suite
-      _delete
+    def after_all
+      self.class._delete
     end
 
     def setup

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -17,7 +17,7 @@ class User < Goo::Base::Resource
   attribute :issues, inverse: { on: Issue, attribute: :owner }
 end
 
-class TestCollection < MiniTest::Unit::TestCase
+class TestCollection < Goo::TestCase
   def initialize(*args)
     super(*args)
   end

--- a/test/test_dsl_settings.rb
+++ b/test/test_dsl_settings.rb
@@ -70,7 +70,7 @@ class YamlSchemeModelTest < Goo::Base::Resource
 end
 
 
-class TestDSLSetting < MiniTest::Unit::TestCase
+class TestDSLSetting < Goo::TestCase
   def initialize(*args)
     super(*args)
   end
@@ -86,7 +86,7 @@ class TestDSLSetting < MiniTest::Unit::TestCase
   def test_default_value
     #default is on save ... returns`
     person = PersonModel.new
-    assert_equal nil, person.created
+    assert_nil person.created
   end
 
   def test_model_with_yaml_scheme

--- a/test/test_email_validator.rb
+++ b/test/test_email_validator.rb
@@ -2,7 +2,7 @@ require_relative 'test_case.rb'
 
 module Goo
   module Validators
-    class TestEmail < MiniTest::Unit::TestCase
+    class TestEmail < Goo::TestCase
 
       def dummy_instance
         @dummy ||= Object.new

--- a/test/test_enum.rb
+++ b/test/test_enum.rb
@@ -10,7 +10,7 @@ module TestEnum
     enum VALUES 
   end 
 
-  class TestEnum < MiniTest::Unit::TestCase
+  class TestEnum < Goo::TestCase
     def initialize(*args)
       super(*args)
     end

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -3,7 +3,7 @@ require_relative './app/models'
 
 module TestIndex
 
-  class TestSchemaless < MiniTest::Unit::TestCase
+  class TestSchemaless < Goo::TestCase
 
     def initialize(*args)
       super(*args)
@@ -12,7 +12,7 @@ module TestIndex
     def setup
     end
 
-    def self.before_suite
+    def before_all
       graph = RDF::URI.new(Test::Models::DATA_ID)
 
       database = Test::Models::Database.new
@@ -28,7 +28,7 @@ module TestIndex
                             mime_type="application/x-turtle")
     end
 
-    def self.after_suite
+    def after_all
       graph = RDF::URI.new(Test::Models::DATA_ID)
       result = Goo.sparql_data_client.delete_graph(graph)
       database = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first

--- a/test/test_inverse.rb
+++ b/test/test_inverse.rb
@@ -21,13 +21,13 @@ end
 
 
 
-class TestInverse < MiniTest::Unit::TestCase
+class TestInverse < Goo::TestCase
 
   def initialize(*args)
     super(*args)
   end
 
-  def self.before_suite
+  def before_all
     Task.all.each do |x|
       x.delete
     end
@@ -36,7 +36,7 @@ class TestInverse < MiniTest::Unit::TestCase
     end
   end
 
-  def self.after_suite
+  def after_all
     Task.all.each do |x|
       x.delete
     end

--- a/test/test_languages_filters.rb
+++ b/test/test_languages_filters.rb
@@ -17,8 +17,8 @@ class ExamplePlace < Goo::Base::Resource
   attribute :label, namespace: :rdf, enforce: [ :list ]
 end
 
-class TestLanguageFilter < MiniTest::Unit::TestCase
-  def self.before_suite
+class TestLanguageFilter < Goo::TestCase
+  def before_all
     RequestStore.store[:requested_lang] = Goo.main_languages.first
     graph = RDF::URI.new(Test::Models::DATA_ID)
 
@@ -39,7 +39,7 @@ class TestLanguageFilter < MiniTest::Unit::TestCase
       mime_type = "application/x-turtle")
   end
 
-  def self.after_suite
+  def after_all
     graph = RDF::URI.new(Test::Models::DATA_ID)
     Goo.sparql_data_client.delete_graph(graph)
     database = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -1,16 +1,16 @@
 require_relative 'test_case'
 require_relative 'models'
 
-class TestLogging < MiniTest::Unit::TestCase
+class TestLogging < Goo::TestCase
 
-  def self.before_suite
+  def before_all
     GooTestData.create_test_case_data
     Goo.use_cache = true
     Goo.redis_client.flushdb
     Goo.add_query_logger(enabled: true, file: "test.log")
   end
 
-  def self.after_suite
+  def after_all
     GooTestData.delete_test_case_data
     Goo.add_query_logger(enabled: false, file: nil)
     File.delete("test.log") if File.exist?("test.log")

--- a/test/test_model_complex.rb
+++ b/test/test_model_complex.rb
@@ -64,14 +64,14 @@ class Term < Goo::Base::Resource
 
 end
 
-class TestModelComplex < MiniTest::Unit::TestCase
+class TestModelComplex < Goo::TestCase
 
 
   def initialize(*args)
     super(*args)
   end
 
-  def self.before_suite
+  def before_all
     Goo.use_cache = false
     if GooTest.count_pattern("?s ?p ?o") > 100000
       raise Exception, "Too many triples in KB, does not seem right to run tests"
@@ -80,7 +80,7 @@ class TestModelComplex < MiniTest::Unit::TestCase
     Goo.sparql_data_client.delete_graph(Submission.uri_type.to_s)
   end
 
-  def self.after_suite
+  def after_all
     Goo.use_cache = false
     Goo.sparql_data_client.delete_graph(Submission.uri_type.to_s)
   end

--- a/test/test_name_with.rb
+++ b/test/test_name_with.rb
@@ -14,7 +14,7 @@ class NameWithAttribute < Goo::Base::Resource
   attribute :name, enforce: [ :existence, :string, :unique ]
 end
 
-class TestNameWith < MiniTest::Unit::TestCase
+class TestNameWith < Goo::TestCase
   def initialize(*args)
     super(*args)
   end

--- a/test/test_namespaces.rb
+++ b/test/test_namespaces.rb
@@ -11,7 +11,7 @@ class NamespacesModel < Goo::Base::Resource
   end
 end
 
-class TestNamespaces < MiniTest::Unit::TestCase
+class TestNamespaces < Goo::TestCase
   def initialize(*args)
     super(*args)
   end

--- a/test/test_schemaless.rb
+++ b/test/test_schemaless.rb
@@ -23,15 +23,15 @@ module TestSchemaless
                         enforce: [:class, :list]
   end
 
-  class TestSchemaless < MiniTest::Unit::TestCase
+  class TestSchemaless < Goo::TestCase
 
     def initialize(*args)
       super(*args)
     end
 
 
-    def self.before_suite
-      _delete
+    def before_all
+      self.class._delete
       graph = RDF::URI.new(ONT_ID)
 
       ont = Ontology.new
@@ -63,8 +63,8 @@ module TestSchemaless
       ont.delete if ont
     end
 
-    def self.after_suite
-      _delete
+    def after_all
+      self.class._delete
     end
 
     def test_alias_props

--- a/test/test_search.rb
+++ b/test/test_search.rb
@@ -90,15 +90,15 @@ module TestSearch
     enable_indexing(:test_solr)
   end
 
-  class TestModelSearch < MiniTest::Unit::TestCase
+  class TestModelSearch < Goo::TestCase
 
-    def self.before_suite
-      cleanup_test_collections
+    def before_all
+      self.class.cleanup_test_collections
       Goo.init_search_connections(true)
     end
 
-    def self.after_suite
-      cleanup_test_collections
+    def after_all
+      self.class.cleanup_test_collections
     end
 
     def self.cleanup_test_collections

--- a/test/test_solr_schema_generator.rb
+++ b/test/test_solr_schema_generator.rb
@@ -1,9 +1,8 @@
-require 'minitest/unit'
-MiniTest::Unit.autorun
+require 'minitest/autorun'
 
 require_relative '../lib/goo/search/solr/solr_schema_generator'
 
-class TestSolrSchemaGenerator < MiniTest::Unit::TestCase
+class TestSolrSchemaGenerator < Minitest::Test
   def setup
     @types = SOLR::SolrSchemaGenerator.new.field_types_to_add
   end

--- a/test/test_update_callbacks.rb
+++ b/test/test_update_callbacks.rb
@@ -16,13 +16,13 @@ class TestUpdateCallBack < Goo::Base::Resource
   end
 end
 
-class TestUpdateCallBacks < MiniTest::Unit::TestCase
+class TestUpdateCallBacks < Goo::TestCase
 
-  def self.before_suite
+  def before_all
     GooTestData.delete_all [TestUpdateCallBack]
   end
 
-  def self.after_suite
+  def after_all
     GooTestData.delete_all [TestUpdateCallBack]
   end
 

--- a/test/test_url_validator.rb
+++ b/test/test_url_validator.rb
@@ -9,7 +9,7 @@ class UrlTestModel < Goo::Base::Resource
   attribute :urls, enforce: %i[list url]
 end
 
-class UrlValidatorTest < Minitest::Unit::TestCase
+class UrlValidatorTest < Goo::TestCase
   def test_url_scalar
     u = UrlTestModel.new
     u.url = RDF::URI.new('https://example.com/path?x=1')

--- a/test/test_validators.rb
+++ b/test/test_validators.rb
@@ -88,9 +88,9 @@ class ProcValidatorsTestModel < Goo::Base::Resource
   end
 end
 
-class TestValidators < MiniTest::Unit::TestCase
+class TestValidators < Goo::TestCase
 
-  def self.before_suite
+  def before_all
     begin
       GooTestData.create_test_case_data
     rescue Exception => e
@@ -98,7 +98,7 @@ class TestValidators < MiniTest::Unit::TestCase
     end
   end
 
-  def self.after_suite
+  def after_all
     GooTestData.delete_test_case_data
     GooTestData.delete_all [SymmetricTestModel, InverseOfTestModel]
   end

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -1,13 +1,13 @@
 require_relative 'test_case'
 require_relative 'models'
 
-class TestWhere < MiniTest::Unit::TestCase
+class TestWhere < Goo::TestCase
 
   def initialize(*args)
     super(*args)
   end
 
-  def self.before_suite
+  def before_all
     begin
       GooTestData.create_test_case_data
     rescue Exception => e
@@ -15,7 +15,7 @@ class TestWhere < MiniTest::Unit::TestCase
     end
   end
 
-  def self.after_suite
+  def after_all
     GooTestData.delete_test_case_data
   end
 


### PR DESCRIPTION
Upgrades the test framework from the end-of-life **minitest 4.7.5** to **minitest 6** and removes goo's custom `GooTest::Unit` runner in favor of idiomatic minitest hooks. Framework-only change — no test logic or assertions were rewritten beyond the mechanics the new version requires.

## Why this isn't a one-line bump
- minitest 4 is EOL, and minitest 6 deleted the APIs goo's runner relied on: `MiniTest::Unit.runner=`, `MiniTest::Unit::TestCase`, and the `_run_suites`/`_run_suite` override points.
- Old `activesupport 4.0.13` itself pinned `minitest ~> 4.2` — that's *why* minitest was stuck at 4. Bumping minitest cascades activesupport to **8.1.3** (the same version `ontologies_linked_data` locks).
- That cascade exposed a latent require gap: `blank?` only worked because activesupport 4's `core_ext/string` pulled it in transitively; activesupport 8 does not. Fixed by requiring `active_support/core_ext/object/blank`.

## Pin: `~> 6.0` (floor is genuinely 6)
The harness rewrite relies on `Minitest::Runnable.run_suite`, which minitest **6** introduced (`Runnable.run -> run_suite`, per the 6.0 changelog). A looser pin could resolve to a version where these hooks never fire, so 6 is the real floor. 6.0.6 is the line oLD already runs.

## Test harness — idiomatic, no custom runner
- Added the **`minitest-hooks`** gem and a `Goo::TestCase < Minitest::Test` base class that `include`s `Minitest::Hooks`. All goo tests now subclass `Goo::TestCase` (the standalone `test_solr_schema_generator.rb`, which doesn't load `test_case.rb`, stays `Minitest::Test`).
- Converted each suite's `self.before_suite`/`self.after_suite` class methods to minitest-hooks `before_all`/`after_all` (run once per suite). Suites that called sibling class methods (`_delete`, `cleanup_test_collections`) now call them via `self.class.`.
- Dropped the old slice-loading-size machinery: it set `Goo.slice_loading_size` to its own current value (a no-op; default stays 500) and only printed a per-suite banner, so nothing of substance is lost. The one test that mutates the size restores it via `ensure`.
- Run-wide setup/teardown is now load-time code + `Minitest.after_run` (minitest has no before-all-suites hook). A comment in `test_case.rb` marks where `feature/sparql-query-logging` re-applies its query-count run totals after rebasing.

## Mechanical
- `MiniTest::Unit::TestCase` → `Goo::TestCase`
- `require 'minitest/unit'` + `MiniTest::Unit.autorun` → `require 'minitest/autorun'`
- `assert_equal nil, x` → `assert_nil x` (minitest 6 forbids a nil expected value); one dynamic comparison branches on `expected.nil?`

## Verification (Ruby 3.2.10, ontoportal_testkit docker backends)
| Backend | Runs | Failures | Errors | Skips |
|---|---|---|---|---|
| 4store | 170 | 0 | 0 | 4 |
| Virtuoso | 170 | 0 | 0 | 2 |
| AllegroGraph | 170 | 0 | 0 | 2 |

Matches the minitest-4 baseline (170 tests / 0 / 0). Skip-count differences are backend-specific (the 4store-only skip doesn't apply to vo/ag).

## Notes for reviewers / sequencing
- **This should land before the sparql-client de-fork work.** `feature/sparql-client-defork` and `feature/sparql-query-logging` will rebase onto it. During that rebase, the SPARQL query-count run-total + cache-hit reporting that the logging branch put inside `GooTest::Unit#before_suites`/`#after_suites` must be re-applied as load-time setup (`Goo.enable_query_count_total`) + a `Minitest.after_run { ... }` block — the spot is marked with a comment in `test_case.rb`.
- **Harness style diverges from oLD on purpose.** oLD emulates the old runner by prepending to `Minitest::Runnable`; goo here uses the `minitest-hooks` gem instead (the more idiomatic route). Flagging in case you'd prefer the two repos structurally identical.
- Test suite is not `rubocop-minitest`-clean (~300 pre-existing style offenses, e.g. `assert a == b`), but that's untouched by this PR and tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
