### PR TITLE
chore: enforce minitest style guide with rubocop-minitest

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,6 @@ plugins:
 # Everything is disabled by default; only the Minitest department is enabled.
 AllCops:
   TargetRubyVersion: 3.2
-  NewCops: disable
   SuggestExtensions: false
   DisabledByDefault: true
   Include:
@@ -15,10 +14,10 @@ AllCops:
 Minitest:
   Enabled: true
 
-# Enforce `assert_equal(expected, actual)` order. It's a "pending" cop, so the
-# NewCops: disable above would otherwise leave it off; enable it explicitly.
-# Note: only flips when the actual-position arg is a literal (number/string/etc.);
-# constants like `assert_equal(obj.class, Array)` are left alone by design.
+# Enforce `assert_equal(expected, actual)` order. It's a pending cop (off by
+# default), so enable it explicitly. Only flips when the actual-position arg is
+# a literal (number/string/etc.); constants like `assert_equal(obj.class, Array)`
+# are left alone by design.
 Minitest/LiteralAsActualArgument:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,11 @@ Minitest:
 Minitest/LiteralAsActualArgument:
   Enabled: true
 
+# assert(obj.kind_of?(K)) / assert(obj.is_a?(K)) -> assert_kind_of(K, obj).
+# Pending cop, off by default; enable explicitly.
+Minitest/AssertKindOf:
+  Enabled: true
+
 # Style cops about how many assertions a test has are noisy for goo's
 # integration-style suites and aren't part of the assertion-idiom cleanup.
 Minitest/MultipleAssertions:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,28 @@
+plugins:
+  - rubocop-minitest
+
+# Scoped intentionally narrow: this config exists to enforce the minitest
+# style guide on the test suite, not to roll out full RuboCop across goo.
+# Everything is disabled by default; only the Minitest department is enabled.
+AllCops:
+  TargetRubyVersion: 3.2
+  NewCops: disable
+  SuggestExtensions: false
+  DisabledByDefault: true
+  Include:
+    - 'test/**/*.rb'
+
+Minitest:
+  Enabled: true
+
+# Enforce `assert_equal(expected, actual)` order. It's a "pending" cop, so the
+# NewCops: disable above would otherwise leave it off; enable it explicitly.
+# Note: only flips when the actual-position arg is a literal (number/string/etc.);
+# constants like `assert_equal(obj.class, Array)` are left alone by design.
+Minitest/LiteralAsActualArgument:
+  Enabled: true
+
+# Style cops about how many assertions a test has are noisy for goo's
+# integration-style suites and aren't part of the assertion-idiom cleanup.
+Minitest/MultipleAssertions:
+  Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ group :test do
   gem "minitest", '~> 6.0'
   gem "minitest-hooks" # before_all/after_all (per-suite once) hooks
   gem "pry"
+  gem 'rubocop', require: false
+  gem 'rubocop-minitest', require: false
   gem 'simplecov'
   gem 'simplecov-cobertura' # for submitting code coverage results to codecov.io
   gem 'ontoportal_testkit', github: 'alexskr/ontoportal_testkit', branch: 'main'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,7 @@ GEM
       uri (>= 0.13.1)
     addressable (2.8.9)
       public_suffix (>= 2.0.2, < 8.0)
+    ast (2.4.3)
     base64 (0.3.0)
     bcp47_spec (0.2.1)
     bigdecimal (3.3.1)
@@ -90,7 +91,9 @@ GEM
       concurrent-ruby (~> 1.0)
     io-console (0.8.2)
     json (2.19.1)
+    language_server-protocol (3.17.0.5)
     link_header (0.0.8)
+    lint_roller (1.1.0)
     logger (1.7.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -117,12 +120,17 @@ GEM
       timeout
     netrc (0.11.0)
     ostruct (0.6.3)
+    parallel (1.28.0)
+    parser (3.3.11.1)
+      ast (~> 2.4.1)
+      racc
     prism (1.9.0)
     pry (0.16.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
       reline (>= 0.6.0)
     public_suffix (7.0.5)
+    racc (1.8.1)
     rack (3.2.5)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -135,6 +143,7 @@ GEM
     rack-session (2.1.1)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
+    rainbow (3.1.1)
     rake (13.3.1)
     rdf (3.3.4)
       bcp47_spec (~> 0.2)
@@ -159,6 +168,7 @@ GEM
       redis-client (>= 0.22.0)
     redis-client (0.27.0)
       connection_pool
+    regexp_parser (2.12.0)
     reline (0.6.3)
       io-console (~> 0.5)
     request_store (1.7.0)
@@ -172,6 +182,25 @@ GEM
     rsolr (2.6.0)
       builder (>= 2.1.2)
       faraday (>= 0.9, < 3, != 2.0.0)
+    rubocop (1.88.0)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (>= 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.49.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.49.1)
+      parser (>= 3.3.7.2)
+      prism (~> 1.7)
+    rubocop-minitest (0.39.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.38.0, < 2.0)
+    ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     securerandom (0.4.1)
     simplecov (0.22.0)
@@ -202,6 +231,9 @@ GEM
     timeout (0.6.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     uri (1.1.1)
     uuid (2.3.9)
       macaddr (~> 1.0)
@@ -226,6 +258,8 @@ DEPENDENCIES
   rake
   rdf-raptor!
   request_store
+  rubocop
+  rubocop-minitest
   simplecov
   simplecov-cobertura
   sinatra

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -246,10 +246,10 @@ class TestSolr < Goo::TestCase
     field = connector.fetch_all_fields.select { |f| f['name'] == 'test' }.first
 
     refute_nil field
-    assert_equal field['type'], 'string'
-    assert_equal field['indexed'], true
-    assert_equal field['stored'], true
-    assert_equal field['multiValued'], true
+    assert_equal 'string', field['type']
+    assert field['indexed']
+    assert field['stored']
+    assert field['multiValued']
 
     connector.delete_field('test')
   end

--- a/test/test_basic_persistence.rb
+++ b/test/test_basic_persistence.rb
@@ -79,16 +79,16 @@ class TestBasicPersistence < Goo::TestCase
     st = StatusPersistent.new(description: "some text", active: true)
     assert_equal("some text", st.description)
     assert st.valid?
-    assert !st.persistent?
+    refute st.persistent?
     assert st.modified?
-    assert !st.exist?
-    assert st == st.save 
+    refute st.exist?
+    assert_equal st, st.save 
     assert st.persistent?
-    assert !st.modified?
-    assert nil == st.delete
-    assert !st.exist?
-    assert !st.persistent?
-    assert !st.modified?
+    refute st.modified?
+    assert_nil st.delete
+    refute st.exist?
+    refute st.persistent?
+    refute st.modified?
   end
 
   def test_unique_duplicates_error
@@ -99,7 +99,7 @@ class TestBasicPersistence < Goo::TestCase
     assert st.valid?
     st.save
     st = StatusPersistent.new(description: "some text", active: true)
-    assert !st.valid?
+    refute st.valid?
     assert_instance_of String, st.errors[:description][:duplicate]
     st = StatusPersistent.new(description: "some text 2", active: true)
     assert st.valid?
@@ -117,14 +117,14 @@ class TestBasicPersistence < Goo::TestCase
     #same object but new. We cannot a save duplicate id.
     #code should not contains errors because we cannot tell apart the resources.
     st = StatusPersistent.new(description: "some text", active: true, code: "001")
-    assert !st.valid?
+    refute st.valid?
     assert_instance_of String, st.errors[:description][:duplicate]
-    assert nil == st.errors[:code]
+    assert_nil st.errors[:code]
 
     #here a differente description therefore a different resource.
     #code should contain a duplication error.
     st = StatusPersistent.new(description: "some text 2", active: true, code: "001")
-    assert !st.valid?
+    refute st.valid?
     assert_instance_of String, st.errors[:code][:unique]
 
     st = StatusPersistent.new(description: "some text 2", active: true, code: "002")
@@ -137,7 +137,7 @@ class TestBasicPersistence < Goo::TestCase
     assert_raises Goo::Base::NotValidException do
       st.save
     end
-    assert !st.persistent?
+    refute st.persistent?
   end
 
   def test_find
@@ -158,14 +158,14 @@ class TestBasicPersistence < Goo::TestCase
     end
 
     assert st_from_backend.persistent?
-    assert !st_from_backend.modified?
+    refute st_from_backend.modified?
 
-    assert nil == st_from_backend.delete
-    assert !st_from_backend.exist?
+    assert_nil st_from_backend.delete
+    refute st_from_backend.exist?
 
     not_existent_id = RDF::URI("http://some.bogus.id/x")
     st_from_backend = StatusPersistent.find(not_existent_id).first
-    assert st_from_backend.nil?
+    assert_nil st_from_backend
   end
 
   def test_find_load_all
@@ -187,8 +187,8 @@ class TestBasicPersistence < Goo::TestCase
     assert st_from_backend.fully_loaded?
     assert (st_from_backend.missing_load_attributes.length == 0)
 
-    assert nil == st_from_backend.delete
-    assert !st_from_backend.exist?
+    assert_nil st_from_backend.delete
+    refute st_from_backend.exist?
   end
 
   def test_find_load_some
@@ -206,12 +206,12 @@ class TestBasicPersistence < Goo::TestCase
       st_from_backend.description
     end
 
-    assert !st_from_backend.fully_loaded?
+    refute st_from_backend.fully_loaded?
     assert (st_from_backend.missing_load_attributes.length == 2)
     assert (st_from_backend.missing_load_attributes.include?(:description))
 
-    assert nil == st_from_backend.delete
-    assert !st_from_backend.exist?
+    assert_nil st_from_backend.delete
+    refute st_from_backend.exist?
   end
 
   def test_update_name_with_attribute
@@ -237,11 +237,11 @@ class TestBasicPersistence < Goo::TestCase
     st_from_backend = StatusPersistent.find("some text").include(:active).first
     assert_instance_of(StatusPersistent, st_from_backend)
     assert_equal(st.id, st_from_backend.id)
-    assert_equal(true, st_from_backend.active)
+    assert(st_from_backend.active)
     st_from_backend.delete
 
     st_from_backend = StatusPersistent.find("not there").first
-    assert st_from_backend.nil?
+    assert_nil st_from_backend
   end
 
   def test_update
@@ -252,15 +252,15 @@ class TestBasicPersistence < Goo::TestCase
     st.active = false
     assert(st.modified?)
     st.save
-    assert(!st.modified?)
+    refute(st.modified?)
 
     st_from_backend = StatusPersistent.find(st.id).include(:active).first
     assert (st_from_backend.persistent?)
-    assert !st_from_backend.modified?
-    assert_equal(false, st_from_backend.active)
+    refute st_from_backend.modified?
+    refute(st_from_backend.active)
 
-    assert nil == st_from_backend.delete
-    assert !st_from_backend.exist?
+    assert_nil st_from_backend.delete
+    refute st_from_backend.exist?
   end
 
   def test_update_array_values
@@ -285,7 +285,7 @@ class TestBasicPersistence < Goo::TestCase
     assert_equal ["A", "B", "C"], arr_from_backend.many.sort
 
     arr_from_backend.delete
-    assert !arr_from_backend.exist?
+    refute arr_from_backend.exist?
   end
 
   def test_person_save
@@ -300,7 +300,7 @@ class TestBasicPersistence < Goo::TestCase
     assert person.valid?
     person.save
     assert person.persistent?
-    assert !person.modified?
+    refute person.modified?
 
     assert_nil person.friends
 
@@ -318,7 +318,7 @@ class TestBasicPersistence < Goo::TestCase
     assert_equal(person.created.xmlschema, person_from_backend.created.xmlschema)
 
     person_from_backend.delete
-    assert !person_from_backend.exist?
+    refute person_from_backend.exist?
     st.delete
   end
 
@@ -333,7 +333,7 @@ class TestBasicPersistence < Goo::TestCase
     person2.friends = [person1]
 
     #dependent objects must be persistant
-    assert !person2.valid?
+    refute person2.valid?
     assert person2.errors[:friends][:person_persistent]
 
     person1.save
@@ -347,22 +347,22 @@ class TestBasicPersistence < Goo::TestCase
 
 
     person1.delete
-    assert 0 == GooTest.triples_for_subject(person1.id)
+    assert_equal 0, GooTest.triples_for_subject(person1.id)
     person2.delete
-    assert 0 == GooTest.triples_for_subject(person2.id)
+    assert_equal 0, GooTest.triples_for_subject(person2.id)
   end
 
   def test_empty_list
     person1 = PersonPersistent.new(name: "John", multiple_values: [1,2,3,4], one_number: 99,
                                    birth_date: DateTime.parse('2001-02-03T04:05:06.12'))
     person1.save
-    assert PersonPersistent.find(person1.id).include(:friends).first.friends.length == 0
+    assert_equal 0, PersonPersistent.find(person1.id).include(:friends).first.friends.length
     person1.delete
   end
 
   def test_range
-    assert PersonPersistent == PersonPersistent.range(:friends)
-    assert StatusPersistent == PersonPersistent.range(:status)
+    assert_equal PersonPersistent, PersonPersistent.range(:friends)
+    assert_equal StatusPersistent, PersonPersistent.range(:status)
     assert PersonPersistent.range(:contact_data).new.kind_of?Struct
   end
 
@@ -377,10 +377,10 @@ class TestBasicPersistence < Goo::TestCase
     person1.save
 
     from_backend = PersonPersistent.find("John").include(:birth_date, :contact_data).first
-    assert from_backend.contact_data.class == Array
-    assert from_backend.contact_data.length == 1
-    assert from_backend.contact_data.first.line1 == "line1 value"
-    assert from_backend.contact_data.first.line2 == "line2 value"
+    assert_instance_of Array, from_backend.contact_data
+    assert_equal 1, from_backend.contact_data.length
+    assert_equal "line1 value", from_backend.contact_data.first.line1
+    assert_equal "line2 value", from_backend.contact_data.first.line2
 
     person2 = PersonPersistent.new(name: "Lewis", multiple_values: [1,2,3,4], one_number: 99,
                                    birth_date: DateTime.parse('2001-02-03T04:05:06.12'))
@@ -392,17 +392,17 @@ class TestBasicPersistence < Goo::TestCase
     pps = PersonPersistent.where.include(:name,:contact_data).all
     pps.each do |pp|
       if pp.name == "John"
-        assert pp.contact_data.length == 1
-        assert pp.contact_data.first.line1 == "line1 value"
-        assert pp.contact_data.first.line2 == "line2 value"
+        assert_equal 1, pp.contact_data.length
+        assert_equal "line1 value", pp.contact_data.first.line1
+        assert_equal "line2 value", pp.contact_data.first.line2
       elsif pp.name == "Lewis"
-        assert pp.contact_data.length == 2
+        assert_equal 2, pp.contact_data.length
         pp.contact_data.each do |s|
           assert (s.line1 == "p2 line1 value" && s.line2 == "p2 line2 value") ||
                     (s.line1 == "p2 line1 value X" && s.line2 == "p2 line2 value Y")
         end
       else
-        assert false
+        flunk "unexpected person: #{pp.name}"
       end
     end
 
@@ -410,10 +410,10 @@ class TestBasicPersistence < Goo::TestCase
       p.delete
     end
 
-    assert 0 == GooTest.triples_for_subject(person1.id)
-    assert 0 == GooTest.triples_for_subject(person2.id)
-    assert 0 == GooTest.count_pattern("?p #{Goo.vocabulary(nil)[:line1].to_ntriples} ?o")
-    assert 0 == GooTest.count_pattern("?p #{Goo.vocabulary(nil)[:line2].to_ntriples} ?o")
+    assert_equal 0, GooTest.triples_for_subject(person1.id)
+    assert_equal 0, GooTest.triples_for_subject(person2.id)
+    assert_equal 0, GooTest.count_pattern("?p #{Goo.vocabulary(nil)[:line1].to_ntriples} ?o")
+    assert_equal 0, GooTest.count_pattern("?p #{Goo.vocabulary(nil)[:line2].to_ntriples} ?o")
     st.delete
   end
 
@@ -433,8 +433,8 @@ class TestBasicPersistence < Goo::TestCase
     met.save
     ont.metric = met
     ont.save
-    assert Dep::Ontology.all.length == 1
-    assert Dep::Metric.all.length == 1
+    assert_equal 1, Dep::Ontology.all.length
+    assert_equal 1, Dep::Metric.all.length
 
     ont = Dep::Ontology.where.include(:metric, :name).all.first   
     
@@ -444,8 +444,8 @@ class TestBasicPersistence < Goo::TestCase
     ont.metric.delete
     ont.delete
 
-    assert Dep::Ontology.all.length == 0
-    assert Dep::Metric.all.length == 0
+    assert_equal 0, Dep::Ontology.all.length
+    assert_equal 0, Dep::Metric.all.length
 
   end
 

--- a/test/test_basic_persistence.rb
+++ b/test/test_basic_persistence.rb
@@ -148,7 +148,7 @@ class TestBasicPersistence < Goo::TestCase
     id = st.id
     st_from_backend = StatusPersistent.find(id).first
     assert_instance_of StatusPersistent, st_from_backend
-    assert (st_from_backend.kind_of? Goo::Base::Resource)
+    assert_kind_of Goo::Base::Resource, st_from_backend
     assert_equal id, st_from_backend.id
 
     st.class.attributes.each do |attr|
@@ -363,7 +363,7 @@ class TestBasicPersistence < Goo::TestCase
   def test_range
     assert_equal PersonPersistent, PersonPersistent.range(:friends)
     assert_equal StatusPersistent, PersonPersistent.range(:status)
-    assert PersonPersistent.range(:contact_data).new.kind_of?Struct
+    assert_kind_of Struct, PersonPersistent.range(:contact_data).new
   end
 
   def test_bnode

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -8,17 +8,13 @@ class TestCache < Goo::TestCase
   end
 
   def before_all
-    begin
-      Goo.use_cache=false
-      GooTestData.create_test_case_data
-      redis = Goo.redis_client
-      if redis.dbsize > 100
-        raise Exception, "This redis needs to point to testing server"
-      end
-      redis.flushdb
-    rescue Exception => e
-      puts e.backtrace
+    Goo.use_cache=false
+    GooTestData.create_test_case_data
+    redis = Goo.redis_client
+    if redis.dbsize > 100
+      raise "This redis needs to point to testing server"
     end
+    redis.flushdb
   end
 
   def after_all

--- a/test/test_cache.rb
+++ b/test/test_cache.rb
@@ -42,11 +42,11 @@ class TestCache < Goo::TestCase
   def test_cache_models
     redis = Goo.redis_client
     redis.flushdb
-    assert !Goo.use_cache?
+    refute Goo.use_cache?
     Goo.use_cache=true
     assert Goo.use_cache?
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ]).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     assert programs.first.id.to_s["Stanford/BioInformatics"]
     assert redis.exists("sparql:graph:http://goo.org/default/Program")
     queries = redis.smembers("sparql:graph:http://goo.org/default/Program")
@@ -58,8 +58,8 @@ class TestCache < Goo::TestCase
         key = q
       end
     end
-    assert count == 1
-    assert !key.nil?
+    assert_equal 1, count
+    refute_nil key
     assert redis.exists(key)
 
 
@@ -69,26 +69,26 @@ class TestCache < Goo::TestCase
     prg.save
 
     #invalidated ?
-    assert !redis.sismember("sparql:graph:http://goo.org/default/Program",key)
+    refute redis.sismember("sparql:graph:http://goo.org/default/Program",key)
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ]).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     prg = programs.first
     prg.bring_remaining
 
     #change comes back ?
-    assert prg.credits == 999
+    assert_equal 999, prg.credits
     Goo.use_cache=false
   end
 
   def test_cache_models_back_door
     redis = Goo.redis_client
     redis.flushdb
-    assert !Goo.use_cache?
+    refute Goo.use_cache?
     Goo.use_cache=true
     assert Goo.use_cache?
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ])
                           .include(:students).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     key = nil
     queries = redis.smembers("sparql:graph:http://goo.org/default/Program")
     count = 0
@@ -98,17 +98,17 @@ class TestCache < Goo::TestCase
         key = q
       end
     end
-    assert count == 1
-    assert !key.nil?
+    assert_equal 1, count
+    refute_nil key
     assert redis.exists(key)
     assert redis.sismember("sparql:graph:http://goo.org/default/Program",key)
 
     prg = programs.first
-    assert prg.students.length == 2
+    assert_equal 2, prg.students.length
     prg.students.each do |st|
       st.bring(:name)
     end
-    assert prg.students.map { |x| x.name }.sort == ["Daniel","Susan"]
+    assert_equal ["Daniel","Susan"], prg.students.map { |x| x.name }.sort
 
     data = "<http://goo.org/default/student/Tim> " +
            "<http://goo.org/default/enrolled> " +
@@ -118,18 +118,18 @@ class TestCache < Goo::TestCase
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ])
                           .include(:students).all
     prg = programs.first
-    assert prg.students.length == 3
+    assert_equal 3, prg.students.length
     prg.students.each do |st|
       st.bring(:name)
     end
-    assert prg.students.map { |x| x.name }.sort == ["Daniel","Susan","Tim"]
+    assert_equal ["Daniel","Susan","Tim"], prg.students.map { |x| x.name }.sort
     Goo.use_cache=false
   end
 
   def test_cache_successful_hit
     redis = Goo.redis_client
     redis.flushdb
-    assert !Goo.use_cache?
+    refute Goo.use_cache?
     Goo.use_cache=true
     assert Goo.use_cache?
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ])
@@ -144,8 +144,8 @@ class TestCache < Goo::TestCase
     begin
       programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ])
                           .include(:students).all
-    rescue  Exception
-      assert false, "should be cached"
+    rescue Exception
+      flunk "should be cached"
     end
 
     #from cache

--- a/test/test_collections.rb
+++ b/test/test_collections.rb
@@ -27,14 +27,14 @@ class TestCollection < Goo::TestCase
       User.new(name: "John").save()
     issue = Issue.find("issue1", collection: john).first || 
       Issue.new(description: "issue1", owner: john).save()
-    assert !Issue.find("issue1", collection: john).nil?
+    refute_nil Issue.find("issue1", collection: john)
     assert_raises ArgumentError do
       Issue.find("issue1").first
     end
-    assert issue.owner.id == john.id
+    assert_equal issue.owner.id, john.id
 
     #same reference
-    assert john.object_id == Issue.find("issue1",collection: john).first.owner.object_id
+    assert_equal john.object_id, Issue.find("issue1",collection: john).first.owner.object_id
     owner = Issue.find("issue1",collection: john).first.owner
 
     assert_equal(1,
@@ -70,7 +70,7 @@ class TestCollection < Goo::TestCase
       GooTest.count_pattern(
         "GRAPH #{john.id.to_ntriples} { #{issue.id.to_ntriples} a ?x }" ))
 
-    assert !Issue.new(description: "issue1", owner: less).exist?
+    refute Issue.new(description: "issue1", owner: less).exist?
     #different owner
     issue = Issue.find("issue1", collection: less).first || 
       Issue.new(description: "issue1", owner: less).save()

--- a/test/test_dsl_settings.rb
+++ b/test/test_dsl_settings.rb
@@ -117,31 +117,31 @@ class TestDSLSetting < Goo::TestCase
     assert_equal ["item1", "item2"], attributes_settings[:test_list][:default]
     assert_equal 3.14, attributes_settings[:test_float][:default]
     assert_equal "https://example.com/term1", attributes_settings[:test_uri][:default]
-    assert_equal false, attributes_settings[:test_boolean][:default]
+    refute attributes_settings[:test_boolean][:default]
   end
 
   private
   def _test_attributes_enforce(model)
     person = model.new
     model_key_name = model.model_name
-    assert(person.respond_to? :id)
+    assert_respond_to(person, :id)
     assert(person.kind_of? Goo::Base::Resource)
-    assert !person.valid?
+    refute person.valid?
 
     assert person.errors[:name][:existence]
     assert person.errors[:friends][:existence]
     assert person.errors[:status][:existence]
     assert person.errors[:birth_date][:existence]
     assert person.errors[:one_number][:existence]
-    assert !person.errors[:created]
+    refute person.errors[:created]
 
     person.name = "John"
-    assert !person.valid?
-    assert !person.errors[:name]
+    refute person.valid?
+    refute person.errors[:name]
 
     person.name = 1
     assert_equal 1, person.name
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:name][:string]
     person.name = "John"
 
@@ -149,40 +149,40 @@ class TestDSLSetting < Goo::TestCase
 
 
     person.birth_date = DateTime.parse('2001-02-03T04:05:06.12')
-    assert !person.valid?
-    assert !person.errors[:birth_date]
+    refute person.valid?
+    refute person.errors[:birth_date]
 
     person.birth_date = "X"
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:birth_date][:date_time]
 
     person.birth_date = DateTime.parse('2001-02-03T04:05:06.12')
     assert_equal(DateTime.parse('2001-02-03T04:05:06.12'), person.birth_date)
-    assert !person.valid?
-    assert !person.errors[:birth_date]
+    refute person.valid?
+    refute person.errors[:birth_date]
 
 
     person.multiple_values = [1, 2, 3, 4]
-    assert !person.valid?
-    assert !person.errors[:multiple_values]
+    refute person.valid?
+    refute person.errors[:multiple_values]
 
     person.multiple_values = [1, 2]
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:multiple_values][:min]
 
     person.multiple_values = [1, 2, 3, 4, 5, 6]
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:multiple_values][:max]
 
 
     person.multiple_values = [1, 2, 3, "4", 5, 6]
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:multiple_values][:max]
     assert person.errors[:multiple_values][:integer]
 
     person.multiple_values = [1, 2, 3, 4]
-    assert !person.valid?
-    assert !person.errors[:multiple_values]
+    refute person.valid?
+    refute person.errors[:multiple_values]
 
     assert_raises FrozenError do
       person.multiple_values << 99
@@ -190,38 +190,38 @@ class TestDSLSetting < Goo::TestCase
 
     friends = [model.new , model.new]
     person.friends = friends
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:friends][:no_list]
     person.friends = model.new
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:friends][model_key_name]
     person.friends = "some one"
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:friends][model_key_name]
     person.friends = model.new
 
     person.one_number = 99
-    assert !person.valid?
-    assert !person.errors[:one_number]
+    refute person.valid?
+    refute person.errors[:one_number]
 
     person.one_number = "99"
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:one_number][:integer]
 
     person.one_number = [98, 99]
-    assert !person.valid?
+    refute person.valid?
     assert person.errors[:one_number][:no_list]
 
     person.one_number = 99
     assert_equal(99, person.one_number)
-    assert !person.valid?
-    assert !person.errors[:one_number]
+    refute person.valid?
+    refute person.errors[:one_number]
 
     assert person.errors[:status][:existence]
     person.status = StatusModel.new
 
     #there are assigned objects that are not saved
-    assert !person.valid?
+    refute person.valid?
   end
 
 

--- a/test/test_dsl_settings.rb
+++ b/test/test_dsl_settings.rb
@@ -125,7 +125,7 @@ class TestDSLSetting < Goo::TestCase
     person = model.new
     model_key_name = model.model_name
     assert_respond_to(person, :id)
-    assert(person.kind_of? Goo::Base::Resource)
+    assert_kind_of(Goo::Base::Resource, person)
     refute person.valid?
 
     assert person.errors[:name][:existence]

--- a/test/test_enum.rb
+++ b/test/test_enum.rb
@@ -18,7 +18,7 @@ module TestEnum
     def test_enum
       status = Status.where.include(:description).to_a
       assert_equal 3, status.length
-      assert status.sort_by { |x| x.description }.map { |y| y.description } == VALUES.sort
+      assert_equal status.sort_by { |x| x.description }.map { |y| y.description }, VALUES.sort
       VALUES.each do |x|
         st = Status.find(x).include(:description).to_a.first
         assert_equal(x,st.description)

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -40,12 +40,12 @@ module TestIndex
       db = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first
       res_id = RDF::URI.new "http://www.census.gov/tiger/2002/tlid/124988547"
       l = Test::Models::Line.find(res_id).in(db).first
-      assert l.id == res_id      
+      assert_equal l.id, res_id      
       l = Test::Models::Line.find(res_id).in(db).include(:start,:end).first
-      assert l.start.tiger_lat == "37.614888"
-      assert l.start.tiger_long == "-121.749163"
-      assert l.end.tiger_lat == "37.608914"
-      assert l.end.tiger_long == "-121.745853"
+      assert_equal "37.614888", l.start.tiger_lat
+      assert_equal "-121.749163", l.start.tiger_long
+      assert_equal "37.608914", l.end.tiger_lat
+      assert_equal "-121.745853", l.end.tiger_long
     end
 
     def test_index
@@ -64,7 +64,7 @@ module TestIndex
                 .page(2,10).all
 
       res_not_index.each_index do |x|
-        assert res_not_index[x].start == res_from_index[x].start
+        assert_equal res_not_index[x].start, res_from_index[x].start
       end
     end
 
@@ -72,12 +72,12 @@ module TestIndex
       skip "enable for benchmark"
       db = Test::Models::Database.find(RDF::URI.new(Test::Models::DATA_ID)).first
       page = Test::Models::Line.in(db).page(1,5).all
-      assert page.length == 5
-      assert page.aggregate == 62420
-      assert page.total_pages == (page.aggregate / 5.0).ceil
-      assert page.page_number == 1
+      assert_equal 5, page.length
+      assert_equal 62420, page.aggregate
+      assert_equal page.total_pages, (page.aggregate / 5.0).ceil
+      assert_equal 1, page.page_number
       assert page.next?
-      assert !page.prev?
+      refute page.prev?
 
       page = Test::Models::Line.in(db).page(1,5).include(:start,:end).all
       page.each do |line|
@@ -96,7 +96,7 @@ module TestIndex
         total += page.length
         page_i += 1
       end while page.next?
-      assert total == 62420
+      assert_equal 62420, total
 
     end
   end

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -81,8 +81,8 @@ module TestIndex
 
       page = Test::Models::Line.in(db).page(1,5).include(:start,:end).all
       page.each do |line|
-        assert line.start.is_a?(Struct)
-        assert line.end.is_a?(Struct)
+        assert_kind_of Struct, line.start
+        assert_kind_of Struct, line.end
       end
 
       page_i = 1

--- a/test/test_inverse.rb
+++ b/test/test_inverse.rb
@@ -46,17 +46,17 @@ class TestInverse < Goo::TestCase
   end
 
   def test_inverse_retrieval
-    assert Project.range(:tasks) == Task
-    assert Task.range(:project) == Project
-    assert Goo.models[:task] == Task
-    assert Goo.models[:project] == Project
-    assert Project.attributes(:list).include?(:tasks)
+    assert_equal Task, Project.range(:tasks)
+    assert_equal Project, Task.range(:project)
+    assert_equal Task, Goo.models[:task]
+    assert_equal Project, Goo.models[:project]
+    assert_includes Project.attributes(:list), :tasks
 
     project = Project.new(name: "Goo")
     Project.find("Goo").first.delete if project.exist?
     assert project.valid?
     project.save
-    assert Project.where.include(:tasks).all.first.tasks == []
+    assert_equal [], Project.where.include(:tasks).all.first.tasks
     assert project.persistent?
     assert_equal(0,
       GooTest.count_pattern(
@@ -72,13 +72,13 @@ class TestInverse < Goo::TestCase
     #task => project
     5.times do |i|
       task = Task.find("task_#{i}").include(:project).first
-      assert task.project.first.id == project.id
+      assert_equal task.project.first.id, project.id
     end
 
     #project => task
     project = Project.find("Goo").include(:tasks).first
     assert_equal(5, project.tasks.length)
-    assert project.tasks.map { |x| x.id.to_s[33].to_i }.sort == [0,1,2,3,4]
+    assert_equal [0,1,2,3,4], project.tasks.map { |x| x.id.to_s[33].to_i }.sort
 
 
     #do not allow to assign inverse properties
@@ -104,7 +104,7 @@ class TestInverse < Goo::TestCase
     Task.find("task_3").first.delete()
     Task.find("task_4").first.delete()
     assert_equal(2, project.tasks.length)
-    assert project.tasks.map { |x| x.id.to_s[33].to_i }.sort == [3,4]
+    assert_equal [3,4], project.tasks.map { |x| x.id.to_s[33].to_i }.sort
     project = Project.find("Goo").include(:tasks).first
     project.delete
 

--- a/test/test_logging.rb
+++ b/test/test_logging.rb
@@ -28,7 +28,7 @@ class TestLogging < Goo::TestCase
     recent_logs = Goo.logger.get_logs
     assert_equal 2, recent_logs.length
     assert recent_logs.any? { |x| x['query'].include?("Test logging") }
-    assert File.read("test.log").include?("Test logging")
+    assert_includes File.read("test.log"), "Test logging"
   end
 
   def test_last_10s_logs
@@ -37,7 +37,7 @@ class TestLogging < Goo::TestCase
     recent_logs = Goo.logger.queries_last_n_seconds(10)
     assert_equal 2, recent_logs.length
     assert recent_logs.any? { |x| x['query'].include?("Test logging 2") }
-    assert File.read("test.log").include?("Test logging 2")
+    assert_includes File.read("test.log"), "Test logging 2"
     sleep 1
     recent_logs = Goo.logger.queries_last_n_seconds(0)
     assert_equal 0, recent_logs.length

--- a/test/test_model_complex.rb
+++ b/test/test_model_complex.rb
@@ -428,8 +428,8 @@ class TestModelComplex < Goo::TestCase
         assert_equal (Set.new t.parents).length, t.parents.length
         assert_equal 2, t.parents.length
         assert_equal 2, t.definition.length
-        assert t.parents[0].kind_of?(Term)
-        assert t.parents[1].kind_of?(Term)
+        assert_kind_of Term, t.parents[0]
+        assert_kind_of Term, t.parents[1]
         assert_equal 1, (t.parents.select { |x| x.id.to_s == "http://someiri.org/cargo" }).length
         assert_equal 1, (t.parents.select { |x| x.id.to_s == "http://someiri.org/van" }).length
       end
@@ -439,7 +439,7 @@ class TestModelComplex < Goo::TestCase
         assert_equal "mini-van", obj_sy.first
         assert_equal "syn minivan", obj_sy[1]
         assert_equal 1, t.parents.length
-        assert t.parents[0].kind_of?(Term)
+        assert_kind_of Term, t.parents[0]
         assert_equal "http://someiri.org/van", t.parents[0].id.to_s
       end
       if t.id.to_s == "http://someiri.org/vehicle"

--- a/test/test_model_complex.rb
+++ b/test/test_model_complex.rb
@@ -89,7 +89,7 @@ class TestModelComplex < Goo::TestCase
     x = Term.new 
     y = x.methodBased
     x.methodBased
-    assert y == "aaaa"
+    assert_equal "aaaa", y
     assert_raises ArgumentError do
       x.methodBased= "aaaa"
     end
@@ -101,7 +101,7 @@ class TestModelComplex < Goo::TestCase
     # Chech the methodBased is not included
     y = Term.find(x.id).in(sub).include(:methodBased).first
     assert_kind_of TestComplex::Term, y
-    refute y.loaded_attributes.include?(:methodBased)
+    refute_includes y.loaded_attributes, :methodBased
     
     assert_raises ArgumentError do
       y = Term.find(x.id).in(sub).include(methodBased: [:prefLabel]).first
@@ -112,7 +112,7 @@ class TestModelComplex < Goo::TestCase
     assert_kind_of Array, y
     refute_empty y
     assert_kind_of TestComplex::Term, y.first
-    refute y.first.loaded_attributes.include?(:methodBased)
+    refute_includes y.first.loaded_attributes, :methodBased
     
     # Chech the methodBased is brought by the bring
     y = Term.find(x.id).in(sub).first
@@ -150,8 +150,8 @@ class TestModelComplex < Goo::TestCase
       vehicle.prefLabel = "vehicle#{x}"
       vehicle.synonym = ["transport#{x}", "vehicles#{x}"]
       vehicle.definition = ["vehicle def 1", "vehicle def 2"]
-      assert !vehicle.valid?
-      assert !vehicle.errors[:id].nil?
+      refute vehicle.valid?
+      refute_nil vehicle.errors[:id]
       vehicle.id = RDF::URI.new "http://someiri.org/vehicle/#{x}"
       assert vehicle.valid?
       vehicle.save
@@ -164,21 +164,21 @@ class TestModelComplex < Goo::TestCase
       "GRAPH #{ss1.id.to_ntriples} { ?s a #{Term.type_uri(ss1).to_ntriples} . }")
 
     res =  Term.find("http://someiri.org/vehicle/0").in(ss1).first
-    assert res.id == RDF::URI.new("http://someiri.org/vehicle/0")
+    assert_equal res.id, RDF::URI.new("http://someiri.org/vehicle/0")
 
     Term.where.in([ss1,ss2]).include(:prefLabel,:synonym).all.each do |term|
       assert [0,1,3,4,6,7,9].index(term.id.to_s[-1].to_i)
-      assert term.prefLabel.to_s[-1].to_i == term.id.to_s[-1].to_i
+      assert_equal term.prefLabel.to_s[-1].to_i, term.id.to_s[-1].to_i
       term.synonym.each do |sy|
-        assert sy.to_s[-1].to_i == term.id.to_s[-1].to_i
+        assert_equal sy.to_s[-1].to_i, term.id.to_s[-1].to_i
       end
     end
     
     Term.where.in([ss3]).include(:prefLabel,:synonym).all.each do |term|
       assert [2,5,8].index(term.id.to_s[-1].to_i)
-      assert term.prefLabel.to_s[-1].to_i == term.id.to_s[-1].to_i
+      assert_equal term.prefLabel.to_s[-1].to_i, term.id.to_s[-1].to_i
       term.synonym.each do |sy|
-        assert sy.to_s[-1].to_i == term.id.to_s[-1].to_i
+        assert_equal sy.to_s[-1].to_i, term.id.to_s[-1].to_i
       end
     end
 
@@ -213,8 +213,8 @@ class TestModelComplex < Goo::TestCase
     vehicle.prefLabel = "vehicle"
     vehicle.synonym = ["transport", "vehicles"]
     vehicle.definition = ["vehicle def 1", "vehicle def 2"]
-    assert !vehicle.valid?
-    assert !vehicle.errors[:id].nil?
+    refute vehicle.valid?
+    refute_nil vehicle.errors[:id]
     vehicle.id = RDF::URI.new "http://someiri.org/vehicle"
     assert vehicle.valid?
     vehicle.save
@@ -226,11 +226,11 @@ class TestModelComplex < Goo::TestCase
     end
 
     res =  Term.find("http://someiri.org/vehicle").in(submission).first
-    assert res.id == RDF::URI.new("http://someiri.org/vehicle")
+    assert_equal res.id, RDF::URI.new("http://someiri.org/vehicle")
 
     #nil
     res =  Term.find("http://xxx").in(submission).first
-    assert res.nil?
+    assert_nil res
 
     #should fail no collection 
     assert_raises ArgumentError do
@@ -243,14 +243,14 @@ class TestModelComplex < Goo::TestCase
           .first
 
     assert_instance_of Term, ts
-    assert "vehicle" == ts.prefLabel
-    assert ts.synonym.length == 2
-    assert (ts.synonym.select { |s| s == "transport"}).length == 1
-    assert (ts.synonym.select { |s| s == "vehicles"}).length == 1
+    assert_equal "vehicle", ts.prefLabel
+    assert_equal 2, ts.synonym.length
+    assert_equal 1, (ts.synonym.select { |s| s == "transport"}).length
+    assert_equal 1, (ts.synonym.select { |s| s == "vehicles"}).length
     
     #all terms for a collection
     terms = Term.where.in(submission).include(Term.attributes).all
-    assert terms.length == 1
+    assert_equal 1, terms.length
     term = terms[0]
     term.submission.id == RDF::URI.new("http://goo.org/default/submission/submission1")
     term.deprecated = false
@@ -305,14 +305,14 @@ class TestModelComplex < Goo::TestCase
     t2.save
 
    t1x = Term.find(RDF::URI.new("http://someiri.org/term")).in(s1).include(Term.attributes).first
-   assert t1x.prefLabel ==  "label1"
+   assert_equal "label1", t1x.prefLabel
    t2x = Term.find(RDF::URI.new("http://someiri.org/term")).in(s2).include(Term.attributes).first
-   assert t2x.prefLabel ==  "label2"
+   assert_equal "label2", t2x.prefLabel
 
    termsS2 = Term.where.in(s2).all
-   assert termsS2.length == 1
+   assert_equal 1, termsS2.length
    termsS1 = Term.where.in(s1).all
-   assert termsS1.length == 2
+   assert_equal 2, termsS1.length
    [s1, s2].each do |s|
      terms = Term.where.in(s).all
      terms.each do |t|
@@ -404,18 +404,18 @@ class TestModelComplex < Goo::TestCase
     vehicle = Term.find(RDF::URI.new("http://someiri.org/vehicle")).in(submission)
                 .include(:children,:parents).first
     ch = vehicle.children
-    assert ch.length == 2
+    assert_equal 2, ch.length
     (ch.select { |c| c.id.to_s == "http://someiri.org/van" }).length == 1
     (ch.select { |c| c.id.to_s == "http://someiri.org/cargo" }).length == 1
-    assert vehicle.parents == []
+    assert_equal [], vehicle.parents
 
 
 
-    assert cargovan.parents.length == 2
+    assert_equal 2, cargovan.parents.length
     #this is confussing
 
     Term.where.models([ cargovan ]).in(submission).include(:children).all
-    assert cargovan.children == []
+    assert_equal [], cargovan.children
 
     #preload attrs
     terms = Term.in(Submission.find("submission1").first).include(:parents,:synonym,:definition)
@@ -423,30 +423,30 @@ class TestModelComplex < Goo::TestCase
       if t.id.to_s == "http://someiri.org/cargovan"
         assert_instance_of Array, t.parents
         obj_sy = t.synonym.sort
-        assert obj_sy.first == "cargo van"
-        assert obj_sy[1] == "syn cargovan"
-        assert (Set.new t.parents).length == t.parents.length
-        assert t.parents.length == 2
-        assert t.definition.length == 2
+        assert_equal "cargo van", obj_sy.first
+        assert_equal "syn cargovan", obj_sy[1]
+        assert_equal (Set.new t.parents).length, t.parents.length
+        assert_equal 2, t.parents.length
+        assert_equal 2, t.definition.length
         assert t.parents[0].kind_of?(Term)
         assert t.parents[1].kind_of?(Term)
-        assert (t.parents.select { |x| x.id.to_s == "http://someiri.org/cargo" }).length == 1
-        assert (t.parents.select { |x| x.id.to_s == "http://someiri.org/van" }).length == 1
+        assert_equal 1, (t.parents.select { |x| x.id.to_s == "http://someiri.org/cargo" }).length
+        assert_equal 1, (t.parents.select { |x| x.id.to_s == "http://someiri.org/van" }).length
       end
       if t.id.to_s == "http://someiri.org/minivan"
         assert_instance_of Array, t.parents
         obj_sy = t.synonym.sort
-        assert obj_sy.first == "mini-van"
-        assert obj_sy[1] == "syn minivan"
-        assert t.parents.length == 1
+        assert_equal "mini-van", obj_sy.first
+        assert_equal "syn minivan", obj_sy[1]
+        assert_equal 1, t.parents.length
         assert t.parents[0].kind_of?(Term)
-        assert t.parents[0].id.to_s == "http://someiri.org/van"
+        assert_equal "http://someiri.org/van", t.parents[0].id.to_s
       end
       if t.id.to_s == "http://someiri.org/vehicle"
-        assert t.parents == []
+        assert_equal [], t.parents
       end
     end
-    assert terms.length == 5
+    assert_equal 5, terms.length
 
     terms = Term.in(submission)
     terms.each do |t|
@@ -480,21 +480,21 @@ class TestModelComplex < Goo::TestCase
 
     #on demand
     terms = Term.in(submission).include(:synonym,:definition).all
-    assert terms.length == 1
-    assert terms.first.synonym.sort ==  ["transport", "vehicles"]
-    assert terms.first.definition ==  []
+    assert_equal 1, terms.length
+    assert_equal ["transport", "vehicles"], terms.first.synonym.sort
+    assert_equal [], terms.first.definition
 
     #preload
     terms = Term.in(submission).include(:synonym, :definition).all
-    assert terms.length == 1
-    assert terms.first.synonym.sort ==  ["transport", "vehicles"]
-    assert terms.first.definition ==  []
+    assert_equal 1, terms.length
+    assert_equal ["transport", "vehicles"], terms.first.synonym.sort
+    assert_equal [], terms.first.definition
 
     #with find
     term = Term.find(RDF::URI.new("http://someiri.org/vehicle")).in(submission).include(:prefLabel, :synonym, :definition).first
-    assert term.synonym.sort ==  ["transport", "vehicles"]
-    assert term.definition ==  []
-    assert term.prefLabel == "vehicle"
+    assert_equal ["transport", "vehicles"], term.synonym.sort
+    assert_equal [], term.definition
+    assert_equal "vehicle", term.prefLabel
 
   end
 
@@ -571,7 +571,7 @@ class TestModelComplex < Goo::TestCase
       elsif t.id.to_s.include? "term/4"
         assert_equal 0, t.aggregates.first.value
       else
-        assert 1 == 0
+        flunk "unexpected term: #{t.id}"
       end
     end
 
@@ -599,7 +599,7 @@ class TestModelComplex < Goo::TestCase
       elsif t.id.to_s.include? "term/9"
         assert_equal 0, t.aggregates.first.value
       else
-        assert 1 == 0
+        flunk "unexpected term: #{t.id}"
       end
     end
 
@@ -615,7 +615,7 @@ class TestModelComplex < Goo::TestCase
       elsif t.id.to_s.include? "term/1"
         assert_equal 1, t.aggregates.first.value
       else
-        assert 1 == 0
+        flunk "unexpected term: #{t.id}"
       end
     end
 
@@ -625,7 +625,7 @@ class TestModelComplex < Goo::TestCase
     ts.each do |t|
       assert_instance_of String, t.prefLabel
       assert_equal Term, t.klass
-      assert_equal RDF::URI, t.id.class
+      assert_instance_of RDF::URI, t.id
       assert_instance_of Array, t.synonym
     end
 
@@ -634,8 +634,8 @@ class TestModelComplex < Goo::TestCase
     assert_equal 3, ts.length
     ts.each do |t|
       assert_instance_of String, t.prefLabel
-      assert t.klass == Term
-      assert t.id.class == RDF::URI
+      assert_equal Term, t.klass
+      assert_instance_of RDF::URI, t.id
       assert_instance_of Array, t.synonym
     end
 
@@ -650,7 +650,7 @@ class TestModelComplex < Goo::TestCase
       elsif t.id.to_s.include? "term/1"
         assert_equal 1, t.aggregates.first.value
       else
-        assert 1 == 0
+        flunk "unexpected term: #{t.id}"
       end
     end
   end

--- a/test/test_name_with.rb
+++ b/test/test_name_with.rb
@@ -52,7 +52,7 @@ class TestNameWith < Goo::TestCase
 
     from_backend.delete
     refute(from_backend.exist?)
-    assert 0, GooTest.triples_for_subject(from_backend.id)
+    assert_equal 0, GooTest.triples_for_subject(from_backend.id)
   end
 
   def test_name_with_attribute
@@ -76,7 +76,7 @@ class TestNameWith < Goo::TestCase
 
     from_backend.delete
     refute(from_backend.exist?)
-    assert 0, GooTest.triples_for_subject(from_backend.id)
+    assert_equal 0, GooTest.triples_for_subject(from_backend.id)
   end
 
 end

--- a/test/test_name_with.rb
+++ b/test/test_name_with.rb
@@ -34,10 +34,10 @@ class TestNameWith < Goo::TestCase
 
   def test_name_with
     nw = NameWith.new(name: "John")
-    assert !nw.exist?
+    refute nw.exist?
     assert_instance_of(RDF::URI, nw.id)
     assert_equal("http://example.org/John/bla",nw.id.to_s)
-    assert !nw.exist?
+    refute nw.exist?
     nw.save
 
     from_backend = NameWith.find(RDF::URI.new("http://example.org/John/bla"), include: [:name]).to_a[0]
@@ -51,7 +51,7 @@ class TestNameWith < Goo::TestCase
     end
 
     from_backend.delete
-    assert(!from_backend.exist?)
+    refute(from_backend.exist?)
     assert 0, GooTest.triples_for_subject(from_backend.id)
   end
 
@@ -59,7 +59,7 @@ class TestNameWith < Goo::TestCase
     nw = NameWithAttribute.new(name: "John")
     assert_instance_of(RDF::URI, nw.id)
     assert_equal("http://goo.org/default/name_with_attribute/John",nw.id.to_s)
-    assert !nw.exist?
+    refute nw.exist?
     nw.save
 
     from_backend = NameWithAttribute.find(
@@ -75,7 +75,7 @@ class TestNameWith < Goo::TestCase
     end
 
     from_backend.delete
-    assert(!from_backend.exist?)
+    refute(from_backend.exist?)
     assert 0, GooTest.triples_for_subject(from_backend.id)
   end
 

--- a/test/test_read_only.rb
+++ b/test/test_read_only.rb
@@ -21,7 +21,7 @@ module TestReadOnly
         st.klass= Student
         assert st.name
         assert st.is_a?Struct
-        assert st.id.class == RDF::URI
+        assert_instance_of RDF::URI, st.id
       end
     end
 
@@ -31,8 +31,8 @@ module TestReadOnly
                 .include(:name,:birth_date)
                 .first
       assert st.kind_of?(Struct)
-      assert st.id == RDF::URI.new("http://goo.org/default/student/Tim")
-      assert st.name == "Tim"
+      assert_equal st.id, RDF::URI.new("http://goo.org/default/student/Tim")
+      assert_equal "Tim", st.name
       assert st.birth_date.kind_of?(DateTime)
     end
 

--- a/test/test_read_only.rb
+++ b/test/test_read_only.rb
@@ -20,7 +20,7 @@ module TestReadOnly
       students.each do |st|
         st.klass= Student
         assert st.name
-        assert st.is_a?Struct
+        assert_kind_of Struct, st
         assert_instance_of RDF::URI, st.id
       end
     end
@@ -30,10 +30,10 @@ module TestReadOnly
                 .read_only
                 .include(:name,:birth_date)
                 .first
-      assert st.kind_of?(Struct)
+      assert_kind_of Struct, st
       assert_equal st.id, RDF::URI.new("http://goo.org/default/student/Tim")
       assert_equal "Tim", st.name
-      assert st.birth_date.kind_of?(DateTime)
+      assert_kind_of DateTime, st.birth_date
     end
 
     def test_embed_struct

--- a/test/test_schemaless.rb
+++ b/test/test_schemaless.rb
@@ -72,52 +72,50 @@ module TestSchemaless
       cognition_term = RDF::URI.new( 
           "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_5400000")
       k = Klass.find(cognition_term).in(ontology).include(:label,:synonym,:definition).first
-      assert k.label == nil #it has rdfs:label but no nemo:pref_label
-      assert k.definition == ["a cognitive_process is a mental process engaging one or more systems in the intermediary or integrative processing of signals from the internal (visceral) and external (somatic) environments. It is often the result of a sensory_process (bottom-up cognition). It may be mediated by an emotion_process (motivated cognition) or by another cognitive_process, such as memory or expectancy based on prior experience (top-down cognition)."]
+      assert_nil k.label #it has rdfs:label but no nemo:pref_label
+      assert_equal ["a cognitive_process is a mental process engaging one or more systems in the intermediary or integrative processing of signals from the internal (visceral) and external (somatic) environments. It is often the result of a sensory_process (bottom-up cognition). It may be mediated by an emotion_process (motivated cognition) or by another cognitive_process, such as memory or expectancy based on prior experience (top-down cognition)."], k.definition
 
-      assert k.synonym.sort == 
-            ["http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800",
+      assert_equal k.synonym.sort, ["http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800",
              "cognition"].sort
 
       pato = RDF::URI.new("http://purl.org/obo/owl/PATO#PATO_0000051")
       k = Klass.find(pato).in(ontology).include(:label,:synonym,:definition).first
-      assert k.label == "morphology"
-      assert k.definition == ["A quality of a single physical entity inhering in the bearer by virtue of the bearer's size, shape and structure."]
-      assert k.synonym == []
+      assert_equal "morphology", k.label
+      assert_equal ["A quality of a single physical entity inhering in the bearer by virtue of the bearer's size, shape and structure."], k.definition
+      assert_equal [], k.synonym
     end
 
     def test_find_include_schemaless
       ontology = Ontology.find(RDF::URI.new(ONT_ID)).first
-      cognition_term = RDF::URI.new( 
+      cognition_term = RDF::URI.new(
           "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_5400000")
       k = Klass.find(cognition_term).in(ontology).first
-      assert k.id.to_s == cognition_term 
+      assert_equal k.id.to_s, cognition_term
       assert_raises Goo::Base::AttributeNotLoaded do
         k.label
       end
       k = Klass.find(cognition_term).in(ontology).include(:label).first
-      assert k.ontology.id == ONT_ID
-      assert k.id.to_s == cognition_term 
-      assert k.label == nil
+      assert_equal ONT_ID, k.ontology.id
+      assert_equal k.id.to_s, cognition_term
+      assert_nil k.label
       assert_raises Goo::Base::AttributeNotLoaded do
         k.definition
       end
       k = Klass.find(cognition_term).in(ontology).include(Klass.attributes).first
-      assert k.label == nil
-      assert k.definition.length == 1
+      assert_nil k.label
+      assert_equal 1, k.definition.length
       assert k.definition.first["a cognitive_process is a mental process"]
-      assert k.synonym.sort == ["cognition",
- "http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800"]
-      assert k.comment == []
-      assert k.parents.length == 1
-      assert k.parents.first.id.to_s == 
-        "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_4320000"
+      assert_equal ["cognition",
+ "http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800"], k.synonym.sort
+      assert_equal [], k.comment
+      assert_equal 1, k.parents.length
+      assert_equal "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_4320000", k.parents.first.id.to_s
 
       where = Klass.find(cognition_term).in(ontology).include(:unmapped)
       k =  where.first
       enter = 0
 
-      assert k.unmapped.keys.include?(Goo.vocabulary(:nemo)[:definition])
+      assert_includes k.unmapped.keys, Goo.vocabulary(:nemo)[:definition]
 
       k.unmapped.each do |p,vals|
         if p.to_s == Goo.vocabulary(:nemo)[:synonym].to_s
@@ -136,22 +134,21 @@ module TestSchemaless
           enter += 1
         end
       end
-      assert enter == 3
+      assert_equal 3, enter
       assert_raises Goo::Base::AttributeNotLoaded do
         k.label
       end
       Klass.map_attributes(k,where.equivalent_predicates)
-      assert k.label == nil
-      assert k.definition.length == 1
+      assert_nil k.label
+      assert_equal 1, k.definition.length
       assert k.definition.first["a cognitive_process is a mental process"]
       assert k.onto_definition.first["mental_process is a brain_ph"]
-      assert k.synonym.sort == ["cognition",
- "http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800"]
-      assert k.comment == []
-      assert k.parents.length == 1
+      assert_equal ["cognition",
+ "http://ontology.neuinfo.org/NIF/Function/NIF-Function.owl#birnlex_1800"], k.synonym.sort
+      assert_equal [], k.comment
+      assert_equal 1, k.parents.length
       assert_instance_of Klass, k.parents.first
-      assert k.parents.first.id.to_s == 
-        "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_4320000"
+      assert_equal "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_4320000", k.parents.first.id.to_s
 
     end
 
@@ -161,7 +158,7 @@ module TestSchemaless
       cognition_term = 
         RDF::URI.new "http://purl.bioontology.org/NEMO/ontology/NEMO.owl#NEMO_5400000"
       k = Klass.find(cognition_term).in(ontology).include(parents: [:label]).first
-      assert k.parents.first.label == nil
+      assert_nil k.parents.first.label
     end
 
 
@@ -186,7 +183,7 @@ module TestSchemaless
       end
 
     end
-    
+
     def test_all_pages_loop
       ontology = Ontology.find(RDF::URI.new(ONT_ID)).first
       page = 1
@@ -208,8 +205,7 @@ module TestSchemaless
       begin
         if paging.instance_variable_get("@page_i") > 1
           #we test that the predicates array is always the same object.
-          assert predicates_array.object_id == 
-            paging.instance_variable_get("@predicates").object_id
+          assert_equal predicates_array.object_id, paging.instance_variable_get("@predicates").object_id
         end
 
         page = paging.to_a
@@ -222,10 +218,10 @@ module TestSchemaless
         end
         total += page.length
         paging.page(page.next_page, 100) if page.next?
-        assert page.aggregate == 1713
+        assert_equal 1713, page.aggregate
       end while(page.next?)
-      assert all_ids.length == all_ids.uniq.length
-      assert total == 1713
+      assert_equal all_ids.length, all_ids.uniq.length
+      assert_equal 1713, total
     end
 
     def test_index_roots
@@ -243,7 +239,7 @@ module TestSchemaless
                 .all
       roots.each do |r|
         #roots have no parents
-        assert Klass.find(r.id).in(ontology).include(:parents).first.parents == []
+        assert_equal [], Klass.find(r.id).in(ontology).include(:parents).first.parents
       end
     end
   end

--- a/test/test_solr_schema_generator.rb
+++ b/test/test_solr_schema_generator.rb
@@ -17,7 +17,7 @@ class TestSolrSchemaGenerator < Minitest::Test
   end
 
   def test_string_ci_exact_omits_term_freq_and_positions
-    assert_equal true, find_type('string_ci_exact')[:omitTermFreqAndPositions],
+    assert find_type('string_ci_exact')[:omitTermFreqAndPositions],
                  'string_ci_exact must set omitTermFreqAndPositions for binary scoring'
   end
 

--- a/test/test_validators.rb
+++ b/test/test_validators.rb
@@ -91,11 +91,7 @@ end
 class TestValidators < Goo::TestCase
 
   def before_all
-    begin
-      GooTestData.create_test_case_data
-    rescue Exception => e
-      puts e.message
-    end
+    GooTestData.create_test_case_data
   end
 
   def after_all

--- a/test/test_validators.rb
+++ b/test/test_validators.rb
@@ -170,7 +170,7 @@ class TestValidators < Goo::TestCase
     m.first_name = 'Michael'
     refute m.valid?
     assert_equal 1, m.errors.keys.length
-    assert m.errors[:first_name][:safe_text_5].include?('and must not exceed 5 characters')
+    assert_includes m.errors[:first_name][:safe_text_5], 'and must not exceed 5 characters'
 
     m.first_name = 'Joe'
     m.description = 'The name Susan 🌍 carries a rich history'

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -83,44 +83,44 @@ class TestWhere < Goo::TestCase
     cats.each do |cats|
       assert_instance_of String, cats.code
     end
-    assert University.where().length == 3
-    assert Address.where().length == 3
-    assert Category.where().length == 7
+    assert_equal 3, University.where().length
+    assert_equal 3, Address.where().length
+    assert_equal 7, Category.where().length
   end
 
   def test_where_1levels
     programs = Program.where(name: "BioInformatics", university: [ name: "Stanford"  ]).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     assert programs.first.id.to_s["Stanford/BioInformatics"]
   end
 
   def test_where_2levels
     programs = Program.where(name: "BioInformatics", university: [ address: [ country: "US" ]]).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     assert programs.first.id.to_s["Stanford/BioInformatics"]
     programs = Program.where(name: "BioInformatics", university: [ address: [ country: "UK" ]]).all
-    assert programs.length == 1
+    assert_equal 1, programs.length
     assert programs.first.id.to_s["Southampton/BioInformatics"]
 
     #any program from universities in the US
     programs = Program.where(university: [ address: [ country: "US" ]]).include([:name]).all
-    assert programs.length == 3
-    assert programs.map { |p| p.name }.sort == ["BioInformatics", "CompSci", "Medicine"]
+    assert_equal 3, programs.length
+    assert_equal ["BioInformatics", "CompSci", "Medicine"], programs.map { |p| p.name }.sort
   end
 
   def test_where_2levels_inverse
     unis = University.where(address: [country: "US"], programs: [category: [code: "Biology"]]).all
-    assert unis.length == 1
-    assert unis.first.id.to_s == "http://goo.org/default/university/Stanford"
+    assert_equal 1, unis.length
+    assert_equal "http://goo.org/default/university/Stanford", unis.first.id.to_s
     unis = University.where(programs: [category: [code: "Biology"]]).include(:name).all
-    assert unis.length == 3
-    assert unis.map { |u| u.name }.sort == ["Southampton", "Stanford", "UPM"]
+    assert_equal 3, unis.length
+    assert_equal ["Southampton", "Stanford", "UPM"], unis.map { |u| u.name }.sort
 
     #equivalent
     unis = University.where(address: [country: "US"])
                      .and(programs: [category: [code: "Biology"]]).all
-    assert unis.length == 1
-    assert unis.first.id.to_s == "http://goo.org/default/university/Stanford"
+    assert_equal 1, unis.length
+    assert_equal "http://goo.org/default/university/Stanford", unis.first.id.to_s
   end
 
   def test_embed_include
@@ -128,17 +128,17 @@ class TestWhere < Goo::TestCase
                       .include(university: [:name])
                       .include(category: [:code]).all
 
-    assert programs.length == 9
+    assert_equal 9, programs.length
     programs.each do |p|
       assert_instance_of String, p.name
       assert_instance_of University, p.university
       assert_instance_of Array, p.category
-      assert p.category.length == p.category.select { |x| x.instance_of? Category }.length
+      assert_equal p.category.length, p.category.select { |x| x.instance_of? Category }.length
       assert_instance_of String, p.university.name
       assert p.id.to_s[p.university.name]
       PROGRAMS_AND_CATEGORIES.each do |x|
         if p.id.to_s[x[0]]
-          assert x[2].length == p.category.length
+          assert_equal x[2].length, p.category.length
           p.category.each do |c|
             assert_instance_of String, c.code
             assert (x[2].index c.code)
@@ -163,11 +163,11 @@ class TestWhere < Goo::TestCase
   def test_iterative_include_in_place
     unis = University.where.all
     unis_return = University.where.models(unis).include(programs: [:name]).to_a
-    assert unis_return.object_id == unis.object_id
-    assert unis.length == unis_return.length
+    assert_equal unis_return.object_id, unis.object_id
+    assert_equal unis.length, unis_return.length
     return_object_id = unis.map { |x| x.object_id }.uniq.sort
     unis_object_id = unis.map { |x| x.object_id }.uniq.sort
-    assert return_object_id == unis_object_id
+    assert_equal return_object_id, unis_object_id
     unis.each do |u|
       u.programs.each do |p|
         assert_instance_of String, p.name
@@ -178,10 +178,10 @@ class TestWhere < Goo::TestCase
     unis = University.where.all
     unis_return = University.where.models(unis)
                             .include(programs: [:name, students: [:name]]).to_a
-    assert unis_return.object_id == unis.object_id
+    assert_equal unis_return.object_id, unis.object_id
     return_object_id = unis.map { |x| x.object_id }.uniq.sort
     unis_object_id = unis.map { |x| x.object_id }.uniq.sort
-    assert return_object_id == unis_object_id
+    assert_equal return_object_id, unis_object_id
     st_count = 0
     unis.each do |u|
       u.programs.each do |p|
@@ -193,18 +193,18 @@ class TestWhere < Goo::TestCase
         end
       end
     end
-    assert st_count == Student.all.length + 1 #one student is enrolled in two programs
+    assert_equal st_count, Student.all.length + 1 #one student is enrolled in two programs
     
     #two levels in steps
     unis = University.where.all
 
     #first step
     unis_return = University.where.models(unis).include(programs: [:name]).to_a
-    assert unis_return.object_id == unis.object_id
-    assert unis.length == unis_return.length
+    assert_equal unis_return.object_id, unis.object_id
+    assert_equal unis.length, unis_return.length
     return_object_id = unis.map { |x| x.object_id }.uniq.sort
     unis_object_id = unis.map { |x| x.object_id }.uniq.sort
-    assert return_object_id == unis_object_id
+    assert_equal return_object_id, unis_object_id
     p_step_one_ids = Set.new
     unis.each do |u|
       u.programs.each do |p|
@@ -215,11 +215,11 @@ class TestWhere < Goo::TestCase
 
     #second step 
     unis_return = University.where.models(unis).include(programs: [students: [:name]]).to_a
-    assert unis_return.object_id == unis.object_id
-    assert unis.length == unis_return.length
+    assert_equal unis_return.object_id, unis.object_id
+    assert_equal unis.length, unis_return.length
     return_object_id = unis.map { |x| x.object_id }.uniq.sort
     unis_object_id = unis.map { |x| x.object_id }.uniq.sort
-    assert return_object_id == unis_object_id
+    assert_equal return_object_id, unis_object_id
     p_step_two_ids = Set.new
     unis.each do |u|
       u.programs.each do |p|
@@ -228,7 +228,7 @@ class TestWhere < Goo::TestCase
     end
 
     #nested object ids have to be the same in the second loading
-    assert p_step_one_ids == p_step_two_ids
+    assert_equal p_step_one_ids, p_step_two_ids
     st_count = 0
     unis.each do |u|
       u.programs.each do |p|
@@ -240,7 +240,7 @@ class TestWhere < Goo::TestCase
         end
       end
     end
-    assert st_count == Student.all.length + 1 #one student is enrolled in two programs
+    assert_equal st_count, Student.all.length + 1 #one student is enrolled in two programs
 
   end
 
@@ -331,50 +331,50 @@ class TestWhere < Goo::TestCase
     students = Student.where(enrolled: 
                              Program.find(RDF::URI.new("http://example.org/program/Stanford/BioInformatics")).first)
                   .include(:name, :birth_date, enrolled: [:name]).all
-    assert students.length == 2
-    assert students.map { |x| x.name }.sort == ["Daniel","Susan"]
+    assert_equal 2, students.length
+    assert_equal ["Daniel","Susan"], students.map { |x| x.name }.sort
     
     #if programs have the same id then the share the same memory reference
     programs = []
     students.each do |st|
       programs.concat(st.enrolled)
     end
-    assert programs.length == 3
+    assert_equal 3, programs.length
     programs.each do |p|
       assert_instance_of String, p.name
       programs.each do |p2|
         if p.id == p2.id
-          assert p.object_id == p2.object_id
+          assert_equal p.object_id, p2.object_id
         end
       end
     end
-    assert programs.uniq.length == 2
+    assert_equal 2, programs.uniq.length
 
     #Students in a university
     students = Student.where(
       enrolled: [ university: University.find("Stanford").first ])
       .include(:name, :birth_date, enrolled: [category: [:code ]]).all
-    assert students.length == 3
-    assert students.map { |x| x.name }.sort == ["Daniel","John","Susan"]
+    assert_equal 3, students.length
+    assert_equal ["Daniel","John","Susan"], students.map { |x| x.name }.sort
     students = students.sort_by { |x| x.name  }
     daniel = students.first
-    assert daniel.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort == [
+    assert_equal [
       ["Biology", "Computer Science", "Medicine"],
-      ["Computer Science", "Electronics", "Engineering", "Mathematics"]]
+      ["Computer Science", "Electronics", "Engineering", "Mathematics"]], daniel.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort
     john = students[1]
-    assert john.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort == [
-      ["Computer Science", "Electronics", "Engineering", "Mathematics"]]
+    assert_equal [
+      ["Computer Science", "Electronics", "Engineering", "Mathematics"]], john.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort
     susan = students.last
-    assert susan.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort == [
-      ["Biology", "Computer Science", "Medicine"]]
+    assert_equal [
+      ["Biology", "Computer Science", "Medicine"]], susan.enrolled.map { |p| p.category.map { |c| c.code }.sort }.sort
 
     categories = []
     students.each do |st|
       categories.concat(st.enrolled.map { |p| p.category }.flatten)
     end
-    assert categories.length == 14
+    assert_equal 14, categories.length
     uniq_object_refs = categories.map { |x| x.object_id }.uniq
-    assert uniq_object_refs.length == 6
+    assert_equal 6, uniq_object_refs.length
 
   end
 
@@ -384,7 +384,7 @@ class TestWhere < Goo::TestCase
                       .include(:name)
                 .include(enrolled: [:name, university: [ :address ]]).all
 
-    assert students.map { |x| x.name }.sort == ["Daniel","John","Susan"]
+    assert_equal ["Daniel","John","Susan"], students.map { |x| x.name }.sort
     students.each do |s|
       s.enrolled do |p|
         assert_instance_of String, p.name
@@ -403,14 +403,14 @@ class TestWhere < Goo::TestCase
     students = Student.where(enrolled: [category: [ code: "Biology" ]])
                         .and(enrolled: [category: [ code: "Chemistry" ]]).all
 
-    assert students.map { |x| x.id.to_s } == ["http://goo.org/default/student/Louis"] 
+    assert_equal ["http://goo.org/default/student/Louis"], students.map { |x| x.id.to_s } 
 
     #daniel, robert, tim and john ok
     students = Student.where(enrolled: [category: [ code: "Mathematics" ]])
                           .and(enrolled: [category: [ code: "Engineering" ]]).all
-    assert students.map { |x| x.id.to_s }.sort == ["http://goo.org/default/student/Daniel",
+    assert_equal ["http://goo.org/default/student/Daniel",
     "http://goo.org/default/student/John","http://goo.org/default/student/Robert",
-    "http://goo.org/default/student/Tim"] 
+    "http://goo.org/default/student/Tim"], students.map { |x| x.id.to_s }.sort 
 
 
     pattern = Goo::Base::Pattern.new(category: [ code: "Mathematics" ])
@@ -418,7 +418,7 @@ class TestWhere < Goo::TestCase
     #daniel ko. a program with both categories not a student with both categories
     #no one
     students = Student.where(enrolled: pattern).all
-    assert students.length == 0
+    assert_equal 0, students.length
 
   end
 
@@ -429,7 +429,7 @@ class TestWhere < Goo::TestCase
                         .and(enrolled: [category: [ code: "Chemistry" ]])
                         .and(enrolled: [category: [ code: "Biology" ]])
                         .all
-    assert students.map { |x| x.id.to_s } == ["http://goo.org/default/student/Louis"] 
+    assert_equal ["http://goo.org/default/student/Louis"], students.map { |x| x.id.to_s } 
 
   end
 
@@ -438,7 +438,7 @@ class TestWhere < Goo::TestCase
     prs = Program.where(category: [code: "Medicine"])
                         .or(category: [code: "Engineering"]).all
     #all of them 9
-    assert prs.length == 9
+    assert_equal 9, prs.length
    
     #programs in medicine or engineering
     prs = Program.where(category: [code: "Medicine"])
@@ -446,7 +446,7 @@ class TestWhere < Goo::TestCase
     prs.each do |p|
       assert p.id.to_s["BioInformatics"] || p.id.to_s["Medicine"]
     end
-    assert prs.length == 6
+    assert_equal 6, prs.length
   end
 
   def test_where_direct_attributes
@@ -454,21 +454,21 @@ class TestWhere < Goo::TestCase
                 .or(name: "Louis")
                 .or(name: "Lee")
                 .or(name: "John").all
-    assert st.length == 4
+    assert_equal 4, st.length
 
     st = Student.where(name: "Daniel")
                 .and(name: "John").all
-    assert st.length == 0
+    assert_equal 0, st.length
 
     st = Student.where(name: "Daniel")
                 .and(birth_date: DateTime.parse('1978-01-04')).all
-    assert st.length == 1
+    assert_equal 1, st.length
     assert st.first.id.to_s["Daniel"]
 
     st = Student.where(name: "Daniel")
                 .or(name: "Louis")
                 .and(birth_date: DateTime.parse('1978-01-04'))
-    assert st.length == 1
+    assert_equal 1, st.length
     assert st.first.id.to_s["Daniel"]
 
   end
@@ -481,7 +481,7 @@ class TestWhere < Goo::TestCase
                   .and(enrolled: [category: [ code: "Medicine" ]])
                   .and(enrolled: [category: [ code: "Chemistry" ]]).all
     
-    assert st.length == 1
+    assert_equal 1, st.length
     assert st.first.id.to_s["Louis"]
   end
 
@@ -498,8 +498,8 @@ class TestWhere < Goo::TestCase
                        .or(name: "Susan")
                        .and(enrolled: [ category: [ code: "Medicine" ]]) 
                           .include(:name, enrolled: [ university: [ address: [ :country ]]]).all
-    assert st.length == 2
-    assert st.first.name != st[1].name
+    assert_equal 2, st.length
+    refute_equal st.first.name, st[1].name
     st.each do |p|
       assert (p.name == "Susan" || p.name == "Daniel")
       assert Array, p.enrolled
@@ -515,49 +515,49 @@ class TestWhere < Goo::TestCase
 
     f = Goo::Filter.new(:birth_date) > DateTime.parse('1978-01-03')
     st = Student.where.filter(f).all
-    assert st.map { |x| x.id.to_s }.sort == ["http://goo.org/default/student/Daniel",
+    assert_equal ["http://goo.org/default/student/Daniel",
                                              "http://goo.org/default/student/Lee",
                                              "http://goo.org/default/student/Louis",
-                                             "http://goo.org/default/student/Robert"]
+                                             "http://goo.org/default/student/Robert"], st.map { |x| x.id.to_s }.sort
 
     f = (Goo::Filter.new(:birth_date) <= DateTime.parse('1978-01-01'))
           .or(Goo::Filter.new(:birth_date) >= DateTime.parse('1978-01-07'))
     st = Student.where.filter(f).all
-    assert st.map { |x| x.id.to_s }.sort == [
+    assert_equal [
       "http://goo.org/default/student/Robert",
-      "http://goo.org/default/student/Susan"]
+      "http://goo.org/default/student/Susan"], st.map { |x| x.id.to_s }.sort
 
     f = (Goo::Filter.new(:birth_date) <= DateTime.parse('1978-01-01'))
           .or(Goo::Filter.new(:name) == "Daniel")
     st = Student.where.filter(f).all
-    assert st.map { |x| x.id.to_s }.sort == [
+    assert_equal [
       "http://goo.org/default/student/Daniel",
-      "http://goo.org/default/student/Susan"]
+      "http://goo.org/default/student/Susan"], st.map { |x| x.id.to_s }.sort
 
     f = (Goo::Filter.new(:birth_date) > DateTime.parse('1978-01-02'))
           .and(Goo::Filter.new(:birth_date) < DateTime.parse('1978-01-06'))
     st = Student.where.filter(f).all
-    assert st.map { |x| x.id.to_s }.sort == [
+    assert_equal [
       "http://goo.org/default/student/Daniel",
       "http://goo.org/default/student/Louis",
-      "http://goo.org/default/student/Tim"]
+      "http://goo.org/default/student/Tim"], st.map { |x| x.id.to_s }.sort
 
 
     f = Goo::Filter.new(enrolled: [ :credits ]) > 8
     st = Student.where.filter(f).all
-    assert st.map { |x| x.id.to_s } == ["http://goo.org/default/student/Louis"]
+    assert_equal ["http://goo.org/default/student/Louis"], st.map { |x| x.id.to_s }
 
     #students without awards
     f = Goo::Filter.new(:awards).unbound
     st = Student.where.filter(f)
                 .include(:name)
                 .all
-    assert st.map { |x| x.name }.sort == ["John","Tim","Louis","Lee","Robert"].sort
+    assert_equal st.map { |x| x.name }.sort, ["John","Tim","Louis","Lee","Robert"].sort
 
     #unbound on some non existing property
     f = Goo::Filter.new(enrolled: [ :xxx ]).unbound
     st = Student.where.filter(f).all
-    assert st.length == 7
+    assert_equal 7, st.length
 
     f = Goo::Filter.new(:name).regex("n") # will find all students that contains "n" in there name
     st = Student.where.filter(f).include(:name).all # return "John" , "Daniel"  and  "Susan"
@@ -569,17 +569,17 @@ class TestWhere < Goo::TestCase
   def test_aggregated
     #students and awards default
     sts = Student.where.include(:name).aggregate(:count,:awards).all
-    assert sts.length == 7
+    assert_equal 7, sts.length
     sts.each do |st|
       agg = st.aggregates.first
-      assert agg.attribute == :awards
-      assert agg.aggregate == :count
+      assert_equal :awards, agg.attribute
+      assert_equal :count, agg.aggregate
       if st.name == "Susan"
-        assert agg.value == 1
+        assert_equal 1, agg.value
       elsif st.name == "Daniel"
-        assert agg.value == 2
+        assert_equal 2, agg.value
       else
-        assert agg.value == 0
+        assert_equal 0, agg.value
       end
     end
 
@@ -594,25 +594,25 @@ class TestWhere < Goo::TestCase
                     .all
                     .select { |x| x.aggregates.first.value > 1 }
 
-    assert sts.length == 1
-    assert sts.first.name == "Daniel"
+    assert_equal 1, sts.length
+    assert_equal "Daniel", sts.first.name
 
     #Categories per student program categories
     sts = Student.where.include(:name).aggregate(:count, enrolled: [:category]).all
-    assert sts.length == 7
+    assert_equal 7, sts.length
     data = { "Tim" => 4, "John" => 4, "Susan" => 3, 
       "Daniel" => 6, "Louis" => 3, "Lee" => 3, "Robert" => 4 }
     sts.each do |st|
-      assert st.aggregates.first.value == data[st.name]
+      assert_equal st.aggregates.first.value, data[st.name]
     end
     
     
     #Inverse
     #universities with more than 3 programs
     us = University.where.include(:name).aggregate(:count, :programs).all
-    assert us.length == 3
+    assert_equal 3, us.length
     us.each do |u|
-      assert u.aggregates.first.value == 3
+      assert_equal 3, u.aggregates.first.value
     end
 
     #double inverse
@@ -628,9 +628,9 @@ class TestWhere < Goo::TestCase
   # more optimized way of counting that does not create objects
   def test_count
     programs = Program.where(name: "BioInformatics", university: [ address: [ country: "US" ]]).all
-    assert programs.length == Program.where(name: "BioInformatics", university: [ address: [ country: "US" ]]).count
+    assert_equal programs.length, Program.where(name: "BioInformatics", university: [ address: [ country: "US" ]]).count
 
-    assert 9 == Program.where.count
+    assert_equal 9, Program.where.count
   end
 
   def test_include_inverse_with_find

--- a/test/test_where.rb
+++ b/test/test_where.rb
@@ -8,11 +8,7 @@ class TestWhere < Goo::TestCase
   end
 
   def before_all
-    begin
-      GooTestData.create_test_case_data
-    rescue Exception => e
-      puts e.message
-    end
+    GooTestData.create_test_case_data
   end
 
   def after_all
@@ -502,10 +498,10 @@ class TestWhere < Goo::TestCase
     refute_equal st.first.name, st[1].name
     st.each do |p|
       assert (p.name == "Susan" || p.name == "Daniel")
-      assert Array, p.enrolled
+      assert_instance_of Array, p.enrolled
       assert (p.name == "Susan" && p.enrolled.length == 1) ||
                (p.name == "Daniel" && p.enrolled.length == 2)
-      assert String, p.enrolled.first.university.address.first.country
+      assert_instance_of String, p.enrolled.first.university.address.first.country
     end
   end
 


### PR DESCRIPTION
Adopts `rubocop-minitest` (dev-only), brings the test suite to the minitest assertion style guide, and fixes a few test bugs found along the way. Test-only — no production changes.

**Style (rubocop-minitest)**
- Adds `rubocop` + `rubocop-minitest` to the test group and a narrow `.rubocop.yml`: everything disabled by default, only the Minitest department enabled on `test/**` (not a full RuboCop rollout). `Minitest/MultipleAssertions` is off — goo's tests are integration-style with many assertions each.
- `rubocop -A` handled the bulk: `assert_equal` / `refute` / `assert_includes` / `assert_nil`, plus correct `expected, actual` order (`Minitest/LiteralAsActualArgument`, enabled explicitly since it's a pending cop).
- Hand-fixed what the cops can't infer: `assert_equal x, nil` → `assert_nil`; `assert_equal(obj.class, Klass)` → `assert_instance_of`; reordered constant-expected `assert_equal`s; and always-fail guards (`assert_equal 1, 0` / `assert false`) → `flunk`.

**Test fixes**
- Fixed 3 no-op assertions that always passed because the expected value was being passed as `assert`'s message arg, not compared: `assert 0, …` → `assert_equal 0, …`; `assert Array/String, x` → `assert_instance_of …`. (They pass once actually asserting — nothing was hiding behind them.)
- Stopped `before_all` swallowing setup errors: dropped `rescue Exception => e; puts` around `create_test_case_data` (test_cache/test_where/test_validators), so a failed fixture surfaces instead of running tests against missing data — and restores test_cache's redis-not-a-test-server guard the rescue was also swallowing.

Follow-up (not here): nothing runs `rubocop` in CI yet — a `rake rubocop` gate could keep the suite clean.