### PR TITLE
perf: memoize equivalent-predicates map per request

### DIFF
--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -514,6 +514,11 @@ module Goo
 
     def call(env)
       Thread.current[:ncbo_debug] = {}
+      # Arm the per-request equivalent-predicates cache: a graph's sub-property map
+      # is stable within a request, so it is computed once instead of per query
+      # (see Goo::Base::Where#retrieve_equivalent_predicates). Cleared in ensure so
+      # it never leaks across requests.
+      Thread.current[:goo_equivalent_predicates_cache] = {}
       status, headers, response = @app.call(env)
       if Thread.current[:ncbo_debug]
         if Thread.current[:ncbo_debug][:sparql_queries]
@@ -530,6 +535,8 @@ module Goo
         end
       end
       return [status, headers, response]
+    ensure
+      Thread.current[:goo_equivalent_predicates_cache] = nil
     end
   end
 

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -514,11 +514,6 @@ module Goo
 
     def call(env)
       Thread.current[:ncbo_debug] = {}
-      # Arm the per-request equivalent-predicates cache: a graph's sub-property map
-      # is stable within a request, so it is computed once instead of per query
-      # (see Goo::Base::Where#retrieve_equivalent_predicates). Cleared in ensure so
-      # it never leaks across requests.
-      Thread.current[:goo_equivalent_predicates_cache] = {}
       status, headers, response = @app.call(env)
       if Thread.current[:ncbo_debug]
         if Thread.current[:ncbo_debug][:sparql_queries]
@@ -535,8 +530,6 @@ module Goo
         end
       end
       return [status, headers, response]
-    ensure
-      Thread.current[:goo_equivalent_predicates_cache] = nil
     end
   end
 

--- a/lib/goo/base/where.rb
+++ b/lib/goo/base/where.rb
@@ -79,28 +79,43 @@ module Goo
 
       def retrieve_equivalent_predicates()
         return @equivalent_predicates unless @equivalent_predicates.nil?
+        return nil unless @include.first == :unmapped || includes_aliasing()
 
-        equivalent_predicates = nil
-        if @include.first == :unmapped || includes_aliasing()
-          if @where_options_load && @where_options_load[:collection]
-            graph = @where_options_load[:collection].map { |x| x.id }
-          else
-            #TODO review this case
-            raise ArgumentError, "Unmapped wihout collection not tested"
-          end
-          equivalent_predicates = Goo::SPARQL::Queries.sub_property_predicates(graph)
-          #TODO compute closure
-          equivalent_predicates_hash = {}
-          equivalent_predicates.each do |down,up|
-            (equivalent_predicates_hash[up.to_s] ||= Set.new) << down.to_s
-          end
-          equivalent_predicates_hash.delete(Goo.vocabulary(:rdfs)[:label].to_s)
-          closure(equivalent_predicates_hash)
-          equivalent_predicates_hash.each do |k,v|
-            equivalent_predicates_hash[k] << k
-          end
+        unless @where_options_load && @where_options_load[:collection]
+          #TODO review this case
+          raise ArgumentError, "Unmapped wihout collection not tested"
         end
-        return equivalent_predicates_hash
+        graph = @where_options_load[:collection].map { |x| x.id }
+
+        # The sub-property (equivalent-predicates) map for a graph is stable within
+        # a request, but is otherwise recomputed for every aliased/unmapped load --
+        # each one re-fetches the sub-property tuples and re-runs #closure (e.g.
+        # ~17x when building a large class tree). When a request armed the cache
+        # (Goo::Debug), memoize per graph so it is computed once. Outside a request
+        # the cache is nil and we compute each time; goo's redis cache already
+        # invalidates the underlying query, so there is no cross-request staleness.
+        # The map is consumed read-only, so sharing one instance is safe.
+        cache = Thread.current[:goo_equivalent_predicates_cache]
+        @equivalent_predicates =
+          if cache
+            cache[graph.map(&:to_s).sort] ||= compute_equivalent_predicates(graph)
+          else
+            compute_equivalent_predicates(graph)
+          end
+      end
+
+      def compute_equivalent_predicates(graph)
+        tuples = Goo::SPARQL::Queries.sub_property_predicates(graph)
+        equivalent_predicates_hash = {}
+        tuples.each do |down, up|
+          (equivalent_predicates_hash[up.to_s] ||= Set.new) << down.to_s
+        end
+        equivalent_predicates_hash.delete(Goo.vocabulary(:rdfs)[:label].to_s)
+        closure(equivalent_predicates_hash)
+        equivalent_predicates_hash.each do |k, _v|
+          equivalent_predicates_hash[k] << k
+        end
+        equivalent_predicates_hash
       end
 
       def unmmaped_predicates()

--- a/lib/goo/base/where.rb
+++ b/lib/goo/base/where.rb
@@ -1,3 +1,5 @@
+require 'request_store'
+
 module Goo
   module Base
 
@@ -90,14 +92,16 @@ module Goo
         # The sub-property (equivalent-predicates) map for a graph is stable within
         # a request, but is otherwise recomputed for every aliased/unmapped load --
         # each one re-fetches the sub-property tuples and re-runs #closure (e.g.
-        # ~17x when building a large class tree). When a request armed the cache
-        # (Goo::Debug), memoize per graph so it is computed once. Outside a request
-        # the cache is nil and we compute each time; goo's redis cache already
-        # invalidates the underlying query, so there is no cross-request staleness.
-        # The map is consumed read-only, so sharing one instance is safe.
-        cache = Thread.current[:goo_equivalent_predicates_cache]
+        # ~17x when building a large class tree). Inside a request
+        # (RequestStore.active?, armed by RequestStore::Middleware in the API),
+        # memoize per graph so it is computed once; RequestStore clears the store
+        # when the request ends. Outside a request (cron, scripts) RequestStore is
+        # inactive and we compute each time -- cron is where subPropertyOf data
+        # actually changes, so it must not see a stale map. The map is consumed
+        # read-only, so sharing one instance is safe.
         @equivalent_predicates =
-          if cache
+          if RequestStore.active?
+            cache = RequestStore.store[:goo_equivalent_predicates_cache] ||= {}
             cache[graph.map(&:to_s).sort] ||= compute_equivalent_predicates(graph)
           else
             compute_equivalent_predicates(graph)

--- a/test/test_equivalent_predicates_cache.rb
+++ b/test/test_equivalent_predicates_cache.rb
@@ -1,12 +1,14 @@
 require_relative 'test_case'
+require 'request_store'
 
 # Unit tests for the per-request equivalent-predicates (sub-property) map cache in
 # Goo::Base::Where#retrieve_equivalent_predicates. Building a large class tree issues many
 # aliased/unmapped loads against the same graph; each one used to re-fetch the sub-property
-# tuples and re-run #closure. When a request arms the cache (Goo::Debug), the map must be
-# computed once per graph and shared, otherwise it must recompute each time (no behavior
-# change outside a request). These tests spy on Goo::SPARQL::Queries.sub_property_predicates
-# -- the store-bound call the fix elides -- so they need no live backend.
+# tuples and re-run #closure. Inside a request (RequestStore.active?, armed by
+# RequestStore::Middleware in the API) the map must be computed once per graph and shared;
+# outside a request (cron, scripts) it must recompute each time -- no behavior change there.
+# These tests spy on Goo::SPARQL::Queries.sub_property_predicates -- the store-bound call
+# the fix elides -- so they need no live backend.
 class TestEquivalentPredicatesCache < Goo::TestCase
 
   class EqCacheProbe < Goo::Base::Resource
@@ -17,7 +19,8 @@ class TestEquivalentPredicatesCache < Goo::TestCase
   Collection = Struct.new(:id)
 
   def teardown
-    Thread.current[:goo_equivalent_predicates_cache] = nil
+    RequestStore.end!
+    RequestStore.clear!
   end
 
   # A Where set up so retrieve_equivalent_predicates takes the :unmapped branch for `graph`.
@@ -44,34 +47,47 @@ class TestEquivalentPredicatesCache < Goo::TestCase
     Goo::SPARQL::Queries.define_singleton_method(:sub_property_predicates, original)
   end
 
-  def test_map_computed_once_per_graph_when_armed
-    Thread.current[:goo_equivalent_predicates_cache] = {}
+  def test_map_computed_once_per_graph_inside_request
+    RequestStore.begin!
     with_sub_property_spy do |calls|
       maps = Array.new(5) { where_for("http://example.org/eqcache/g1").retrieve_equivalent_predicates }
       assert_equal 1, calls.length,
-                   "an armed request must compute the sub-property map once, not per load"
+                   "inside a request the sub-property map must be computed once, not per load"
       assert maps.all? { |map| map.equal?(maps.first) },
-             "an armed request must hand every load the same cached map instance"
+             "inside a request every load must get the same cached map instance"
     end
   end
 
-  def test_map_recomputed_each_time_when_not_armed
-    Thread.current[:goo_equivalent_predicates_cache] = nil
+  def test_map_recomputed_each_time_outside_request
+    refute RequestStore.active?, "test precondition: no active request scope"
     with_sub_property_spy do |calls|
       5.times { where_for("http://example.org/eqcache/g2").retrieve_equivalent_predicates }
       assert_equal 5, calls.length,
-                   "without an armed cache each load recomputes the map (prior behavior, no request scope)"
+                   "outside a request scope each load recomputes the map (prior behavior; cron must not see a stale map)"
     end
   end
 
   def test_distinct_graphs_are_cached_separately
-    Thread.current[:goo_equivalent_predicates_cache] = {}
+    RequestStore.begin!
     with_sub_property_spy do |calls|
       where_for("http://example.org/eqcache/a").retrieve_equivalent_predicates
       where_for("http://example.org/eqcache/b").retrieve_equivalent_predicates
       where_for("http://example.org/eqcache/a").retrieve_equivalent_predicates
       assert_equal 2, calls.length,
                    "each distinct graph is computed once; a repeat graph is served from the cache"
+    end
+  end
+
+  def test_cache_does_not_survive_request_end
+    RequestStore.begin!
+    with_sub_property_spy do |calls|
+      where_for("http://example.org/eqcache/g3").retrieve_equivalent_predicates
+      RequestStore.end!
+      RequestStore.clear!
+      RequestStore.begin!
+      where_for("http://example.org/eqcache/g3").retrieve_equivalent_predicates
+      assert_equal 2, calls.length,
+                   "a new request must not see the previous request's cached map"
     end
   end
 end

--- a/test/test_equivalent_predicates_cache.rb
+++ b/test/test_equivalent_predicates_cache.rb
@@ -1,0 +1,77 @@
+require_relative 'test_case'
+
+# Unit tests for the per-request equivalent-predicates (sub-property) map cache in
+# Goo::Base::Where#retrieve_equivalent_predicates. Building a large class tree issues many
+# aliased/unmapped loads against the same graph; each one used to re-fetch the sub-property
+# tuples and re-run #closure. When a request arms the cache (Goo::Debug), the map must be
+# computed once per graph and shared, otherwise it must recompute each time (no behavior
+# change outside a request). These tests spy on Goo::SPARQL::Queries.sub_property_predicates
+# -- the store-bound call the fix elides -- so they need no live backend.
+class TestEquivalentPredicatesCache < Goo::TestCase
+
+  class EqCacheProbe < Goo::Base::Resource
+    model :eq_cache_probe, name_with: :id
+    attribute :name
+  end
+
+  Collection = Struct.new(:id)
+
+  def teardown
+    Thread.current[:goo_equivalent_predicates_cache] = nil
+  end
+
+  # A Where set up so retrieve_equivalent_predicates takes the :unmapped branch for `graph`.
+  def where_for(graph)
+    where = Goo::Base::Where.new(EqCacheProbe)
+    where.instance_variable_set(:@include, [:unmapped])
+    where.instance_variable_set(:@where_options_load,
+                                { collection: [Collection.new(RDF::URI.new(graph))] })
+    where
+  end
+
+  # Replace the store-bound sub_property_predicates with a spy that records each call and
+  # returns no tuples (an empty map is enough to exercise the caching path), restoring the
+  # original afterward. Yields the array of recorded calls.
+  def with_sub_property_spy
+    calls = []
+    original = Goo::SPARQL::Queries.method(:sub_property_predicates)
+    Goo::SPARQL::Queries.define_singleton_method(:sub_property_predicates) do |*graphs|
+      calls << graphs
+      []
+    end
+    yield calls
+  ensure
+    Goo::SPARQL::Queries.define_singleton_method(:sub_property_predicates, original)
+  end
+
+  def test_map_computed_once_per_graph_when_armed
+    Thread.current[:goo_equivalent_predicates_cache] = {}
+    with_sub_property_spy do |calls|
+      maps = Array.new(5) { where_for("http://example.org/eqcache/g1").retrieve_equivalent_predicates }
+      assert_equal 1, calls.length,
+                   "an armed request must compute the sub-property map once, not per load"
+      assert maps.all? { |map| map.equal?(maps.first) },
+             "an armed request must hand every load the same cached map instance"
+    end
+  end
+
+  def test_map_recomputed_each_time_when_not_armed
+    Thread.current[:goo_equivalent_predicates_cache] = nil
+    with_sub_property_spy do |calls|
+      5.times { where_for("http://example.org/eqcache/g2").retrieve_equivalent_predicates }
+      assert_equal 5, calls.length,
+                   "without an armed cache each load recomputes the map (prior behavior, no request scope)"
+    end
+  end
+
+  def test_distinct_graphs_are_cached_separately
+    Thread.current[:goo_equivalent_predicates_cache] = {}
+    with_sub_property_spy do |calls|
+      where_for("http://example.org/eqcache/a").retrieve_equivalent_predicates
+      where_for("http://example.org/eqcache/b").retrieve_equivalent_predicates
+      where_for("http://example.org/eqcache/a").retrieve_equivalent_predicates
+      assert_equal 2, calls.length,
+                   "each distinct graph is computed once; a repeat graph is served from the cache"
+    end
+  end
+end


### PR DESCRIPTION
## Problem

`Goo::Base::Where#retrieve_equivalent_predicates` recomputes the sub-property (equivalent-predicates) map on **every** aliased/unmapped load — re-fetching the sub-property tuples via `Goo::SPARQL::Queries.sub_property_predicates` and re-running `#closure` each time. Building a large class tree issues that load per node, so the same graph's map gets rebuilt many times in one request (~17× on a ~3k-node tree).

This is the remaining CPU cost surfacing after the two oLD-side N+1 fixes in ncbo/ontologies_linked_data#302 (which took the `/tree` endpoint from ~35s to ~23s in prod). Profiling the map build alone: **~5.6s → ~0.5s**.

## Fix

Memoize the map per graph in `RequestStore`, guarded by `RequestStore.active?`. `RequestStore::Middleware` is mounted unconditionally in ontologies_api and clears the store when the request ends, so the cache lives exactly one request and never leaks across requests.

Outside a request (cron, scripts) `RequestStore.active?` is false and the map is computed each time, exactly as before — cron is where `subPropertyOf` data actually changes, so it must never see a stale map. The map is consumed read-only, so sharing one instance across loads within a request is safe.

> Note: the first iteration armed a thread-local from `Goo::Debug`, but that middleware is only mounted when `Goo.queries_debug?` is enabled — which no environment config sets — so the cache would never have armed in a default production deploy. RequestStore is already a goo dependency (`RequestStore.store[:requested_lang]`) and its middleware is always on.

The compute logic is extracted verbatim into `compute_equivalent_predicates`; the branch semantics of `retrieve_equivalent_predicates` are unchanged (returns `nil` when not aliased/unmapped, same raise when a collection is missing).

## Testing

- `test/test_equivalent_predicates_cache.rb` spies on `sub_property_predicates` and asserts: computed once per graph inside a request scope, recomputed per load outside one, cached per distinct graph, and not carried across a request boundary. Backend-free.
- Full suite green on all four CI backends (ag/fs/gd/vo) and locally across repeated runs (`development` with the #192 schema-bootstrap fixes merged in).
- `test/test_schemaless.rb` (the real alias/unmapped path) green against staging AllegroGraph (pre-RequestStore iteration; to be re-run).

## Measured on staging (see comment below for full data)

- [x] Re-measured the `/tree` endpoint on staging AG without `QUERIES_DEBUG`: **no measurable speedup**. Direct timing shows the cached operation (`sub_property_predicates` + closure) costs ~10–23 ms per graph across all ontologies tested (incl. IOBC, UBERON, AGROVOC), so eliminating repeated builds saves ~0.2–0.4 s at most — lost in the multi-second WAN-bound tree SPARQL. The 5.6s→0.5s figure did not reproduce on this backend.
- [x] Re-ran `test_schemaless.rb` against AG (staging via tunnel) on the current head: 7 runs, 71 assertions, 0 failures. Refactored alias/unmapped path verified.

The change is still worth keeping as a correct, low-risk cleanup (RequestStore-scoped, read-only, verified). The perf section above should be recharacterized accordingly unless a backend reproducing the original profile is identified.
