### PR TITLE
fix: make Solr schema bootstrap atomic, self-healing, and non-destructive

### DIFF
--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -55,6 +55,7 @@ module Goo
   @@query_logging = false
   @@query_logging_file = './queries.log'
   @@slice_loading_size = 500
+  @@force_rebuild_search_schema = false
 
 
 
@@ -156,6 +157,24 @@ module Goo
 
   def self.use_cache?
     @@use_cache
+  end
+
+  # When enabled, the first initialization of each search collection in this
+  # process rebuilds its schema (init force) instead of trusting whatever an
+  # existing collection contains. FOR TEST/DEV ENVIRONMENTS ONLY: goo's test
+  # harness enables it so runs never depend on state left in Solr by previous
+  # (possibly interrupted) runs. Do NOT enable in production — a forced
+  # rebuild drops every schema field the generator does not declare (e.g.
+  # fields added over time by Solr's data-driven mode), breaking search on
+  # them until a full reindex. Indexed documents themselves are preserved.
+  # Production collections are repaired additively instead (see
+  # SOLR::Schema#repair_schema_additively).
+  def self.force_rebuild_search_schema=(value)
+    @@force_rebuild_search_schema = value
+  end
+
+  def self.force_rebuild_search_schema?
+    @@force_rebuild_search_schema
   end
 
   def self.slice_loading_size=(value)
@@ -398,7 +417,10 @@ module Goo
                                                                    block,
                                                                    num_shards: num_shards,
                                                                    replication_factor: replication_factor)
-    @@search_connection[collection_name].init(force, bootstrap_collection: bootstrap_collection) if initialize_collection
+    # force_rebuild_search_schema? makes the one-time init of this collection
+    # rebuild the schema (see the accessor's comment); afterwards the memoized
+    # connection short-circuits above, so the rebuild happens once per process.
+    @@search_connection[collection_name].init(force || Goo.force_rebuild_search_schema?, bootstrap_collection: bootstrap_collection) if initialize_collection
 
     @@search_connection[collection_name]
   end

--- a/lib/goo/search/solr/solr_connector.rb
+++ b/lib/goo/search/solr/solr_connector.rb
@@ -43,6 +43,13 @@ module SOLR
       # core. This guards against init() with force=false destroying data.
       if collection_exists?(@alias_name) && !alias_exists?(@alias_name)
         @aliased = false
+        # A live collection may carry data-driven fields the generator does
+        # not declare; only ADD what is missing (e.g. a dynamicField dropped
+        # by an interrupted schema update) — never rebuild, which would drop
+        # those fields from the schema and break search on them until a full
+        # reindex. The full rebuild requires explicit force (previously this
+        # early return made force a silent no-op here).
+        force ? init_schema(clear_data: clear_data) : repair_schema_additively
         return self
       end
 
@@ -53,7 +60,11 @@ module SOLR
 
     def init_without_alias(force = false, clear_data: false)
       @aliased = false
-      return if collection_exists?(@collection_name) && !force
+      if collection_exists?(@collection_name)
+        # See init(): additive repair only, unless explicitly forced.
+        force ? init_schema(clear_data: clear_data) : repair_schema_additively
+        return
+      end
 
       create_collection(@collection_name, @num_shards, @replication_factor)
 
@@ -65,7 +76,9 @@ module SOLR
 
       if alias_exists?(@alias_name)
         with_collection(resolve_alias(@alias_name).first) do
-          init_schema(clear_data: clear_data) if force
+          # See init(): additive repair only on the live resolved collection,
+          # unless explicitly forced.
+          force ? init_schema(clear_data: clear_data) : repair_schema_additively
         end
       else
         # Defense-in-depth: the guard in init() should catch this earlier,

--- a/lib/goo/search/solr/solr_schema.rb
+++ b/lib/goo/search/solr/solr_schema.rb
@@ -69,20 +69,36 @@ module SOLR
       end
     end
 
+    # Fields Solr requires (or manages itself) that must never be deleted or re-added.
+    PROTECTED_FIELDS = %w[id _version_ _text_].freeze
+
+    # Rebuild the collection schema in a SINGLE Schema API request. Solr applies
+    # all commands in one request as one atomic schema update: either the new
+    # schema (deletes + adds) lands completely, or nothing changes. The previous
+    # implementation issued the deletes in four separate requests followed by
+    # the adds in a fifth; a failure or interruption in between left the
+    # collection permanently half-configured (e.g. copyField rules whose *_str
+    # dest dynamicField no longer existed — fatal at document-add time in
+    # data-driven mode), poisoning every later run that trusted the collection.
     def init_schema(generator = schema_generator, clear_data: false)
       clear_all_data if clear_data
-      clear_all_schema(generator)
       fetch_schema
-      default_fields = all_fields.map { |f| f['name'] }
 
-      solr_schema = {
-        "add-field-type": generator.field_types_to_add,
-        'add-field' => generator.fields_to_add.reject { |f| default_fields.include?(f[:name]) },
-        'add-dynamic-field' => generator.dynamic_fields_to_add,
-        'add-copy-field' => generator.copy_fields_to_add
-      }
+      # Fields that survive the clear (see clear_schema_commands) must not be re-added.
+      surviving_fields = all_fields.map { |f| f['name'] } & PROTECTED_FIELDS
 
-      update_schema(solr_schema)
+      # Command order matters: within one request Solr executes commands in
+      # order, so deletes go first (copy fields before the fields they
+      # reference, field types last once nothing uses them) and adds follow
+      # (field types before the fields that use them).
+      commands = clear_schema_commands(generator)
+      commands['add-field-type'] = generator.field_types_to_add
+      commands['add-field'] = generator.fields_to_add.reject { |f| surviving_fields.include?(f[:name].to_s) }
+      commands['add-dynamic-field'] = generator.dynamic_fields_to_add
+      commands['add-copy-field'] = generator.copy_fields_to_add
+      commands.reject! { |_action, list| list.nil? || list.empty? }
+
+      update_schema(commands)
     end
 
     def custom_schema?
@@ -94,16 +110,92 @@ module SOLR
     end
 
     def clear_all_schema(generator = schema_generator)
+      fetch_schema
+      commands = clear_schema_commands(generator)
+      upload_schema(commands) unless commands.empty?
+      fetch_schema
+    end
+
+    # Delete commands to reset the current schema, in dependency order:
+    # copy fields first (they reference fields/dynamic fields), field types
+    # last (they can only be deleted once no field uses them). Returned as a
+    # hash so callers can send them in ONE atomic request, alone
+    # (clear_all_schema) or merged with the adds (init_schema).
+    def clear_schema_commands(generator = schema_generator)
       init_ft = generator.field_types_to_add.map { |f| f[:name] }
-      dynamic_fields = all_dynamic_fields.map { |f| { name: f['name'] } }
-      copy_fields = all_copy_fields.map { |f| { source: f['source'], dest: f['dest'] } }
-      fields_types = all_fields_types.select { |f| init_ft.include?(f['name']) }.map { |f| { name: f['name']} }
-      fields = all_fields.reject { |f| %w[id _version_ _text_].include?(f['name']) }.map { |f| { name: f['name'] } }
-      
-      upload_schema('delete-copy-field' => copy_fields) unless copy_fields.empty?
-      upload_schema('delete-dynamic-field' => dynamic_fields) unless dynamic_fields.empty?
-      upload_schema('delete-field' => fields) unless fields.empty?
-      upload_schema('delete-field-type' => fields_types) unless fields_types.empty?
+      copy_fields = (all_copy_fields || []).map { |f| { source: f['source'], dest: f['dest'] } }
+      fields = (all_fields || []).reject { |f| PROTECTED_FIELDS.include?(f['name']) }.map { |f| { name: f['name'] } }
+      dynamic_fields = (all_dynamic_fields || []).map { |f| { name: f['name'] } }
+      fields_types = (all_fields_types || []).select { |f| init_ft.include?(f['name']) }.map { |f| { name: f['name'] } }
+
+      commands = {}
+      commands['delete-copy-field'] = copy_fields unless copy_fields.empty?
+      commands['delete-field'] = fields unless fields.empty?
+      commands['delete-dynamic-field'] = dynamic_fields unless dynamic_fields.empty?
+      commands['delete-field-type'] = fields_types unless fields_types.empty?
+      commands
+    end
+
+    # Add anything the generator declares that is missing from the live
+    # schema, in ONE atomic request, without deleting or altering anything
+    # that already exists. This is the ONLY schema mutation permitted on a
+    # collection that was not just created: live collections legitimately
+    # carry fields the generator knows nothing about (Solr's data-driven mode
+    # adds a schema field for every unknown document key), and a full rebuild
+    # (init_schema) would drop them from the schema, silently breaking search
+    # on them until a full reindex. Existing items with a divergent definition
+    # are left untouched — that is a migration, not bootstrap repair.
+    def repair_schema_additively(generator = schema_generator)
+      current = fetch_schema
+      fields = (current['fields'] || []).map { |f| f['name'] }
+      dynamic_fields = (current['dynamicFields'] || []).map { |f| f['name'] }
+      field_types = (current['fieldTypes'] || []).map { |f| f['name'] }
+      copy_fields = (current['copyFields'] || []).map { |f| [f['source'], f['dest']] }
+
+      missing_field_types = generator.field_types_to_add.reject { |f| field_types.include?(f[:name].to_s) }
+      missing_fields = generator.fields_to_add.reject { |f| fields.include?(f[:name].to_s) }
+      missing_dynamic_fields = generator.dynamic_fields_to_add.reject { |f| dynamic_fields.include?(f[:name].to_s) }
+      missing_copy_fields = generator.copy_fields_to_add.flat_map do |cf|
+        Array(cf[:dest]).reject { |dest| copy_fields.include?([cf[:source].to_s, dest.to_s]) }
+                        .map { |dest| { source: cf[:source], dest: dest } }
+      end
+
+      commands = {}
+      commands['add-field-type'] = missing_field_types unless missing_field_types.empty?
+      commands['add-field'] = missing_fields unless missing_fields.empty?
+      commands['add-dynamic-field'] = missing_dynamic_fields unless missing_dynamic_fields.empty?
+      commands['add-copy-field'] = missing_copy_fields unless missing_copy_fields.empty?
+      return if commands.empty?
+
+      begin
+        update_schema(commands)
+      rescue StandardError
+        # Several processes boot concurrently in production (API workers,
+        # cron); when the same item is missing they race the same add-* and
+        # the loser gets a 400 from Solr. If a concurrent repair already made
+        # the schema whole, this process must not fail its boot over it.
+        raise unless schema_matches_generator?(generator)
+      end
+    end
+
+    # True when everything the generator declares is present in the live
+    # schema (matched by name; definitions are not diffed). Diagnostic
+    # counterpart of repair_schema_additively.
+    def schema_matches_generator?(generator = schema_generator)
+      current = fetch_schema
+      fields = (current['fields'] || []).map { |f| f['name'] }
+      dynamic_fields = (current['dynamicFields'] || []).map { |f| f['name'] }
+      field_types = (current['fieldTypes'] || []).map { |f| f['name'] }
+      copy_fields = (current['copyFields'] || []).map { |f| [f['source'], f['dest']] }
+
+      expected_copy_fields = generator.copy_fields_to_add.flat_map do |cf|
+        Array(cf[:dest]).map { |dest| [cf[:source].to_s, dest.to_s] }
+      end
+
+      generator.fields_to_add.all? { |f| fields.include?(f[:name].to_s) } &&
+        generator.dynamic_fields_to_add.all? { |f| dynamic_fields.include?(f[:name].to_s) } &&
+        generator.field_types_to_add.all? { |f| field_types.include?(f[:name].to_s) } &&
+        expected_copy_fields.all? { |pair| copy_fields.include?(pair) }
     end
 
     def map_to_indexer_type(orm_data_type)

--- a/test/solr/test_solr.rb
+++ b/test/solr/test_solr.rb
@@ -188,7 +188,10 @@ class TestSolr < Goo::TestCase
         assert_equal field["type"], f[:type]
         assert_equal field["indexed"], f[:indexed]
         assert_equal field["stored"], f[:stored]
-        assert_equal field["multiValued"], f[:multiValued]
+        # Both sides may legitimately omit multiValued (Solr then applies the
+        # type default); assert_equal(nil, nil) is a minitest failure, so only
+        # compare when the live schema carries the attribute.
+        assert_equal field["multiValued"], f[:multiValued] unless field["multiValued"].nil?
       end
 
       copy_fields = connector.all_copy_fields
@@ -206,7 +209,8 @@ class TestSolr < Goo::TestCase
         refute_nil field
         assert_equal field["name"], f[:name]
         assert_equal field["type"], f[:type]
-        assert_equal field["multiValued"], f[:multiValued]
+        # See the multiValued note above: skip the nil/nil comparison.
+        assert_equal field["multiValued"], f[:multiValued] unless field["multiValued"].nil?
         assert_equal field["stored"], f[:stored]
       end
 

--- a/test/test_case.rb
+++ b/test/test_case.rb
@@ -99,6 +99,13 @@ end
 #   Goo.enable_query_count_total                       # before all suites
 #   Minitest.after_run { warn "[goo] SPARQL ..." }     # after all suites
 
+# Test runs must not depend on Solr state left behind by previous (possibly
+# interrupted) runs: rebuild each search collection's schema on its first
+# initialization in this process. Collections init lazily (on first use), so
+# this is a flag rather than an eager call — models register their collections
+# when their test file loads, which can be after this file is required.
+Goo.force_rebuild_search_schema = true
+
 module TestHelpers
   def self.test_reset
     TestSafety.ensure_safe_test_targets!


### PR DESCRIPTION
## Problem

Back-to-back test runs alternated between green and red with the same seed (`TestCache` redis guard one run, a Solr 500 — `copyField dest :'synonym_str' is not an explicit field and doesn't match a dynamicField` — the next). Root cause: Solr schema bootstrap was neither atomic nor self-sufficient.

1. **`init_schema` was non-atomic** — deletes went out in four separate Schema API requests, adds in a fifth. Any failure or interruption in between left the collection half-configured (e.g. copyField rules whose `*_str` dest dynamicField no longer existed — fatal at *document-add* time in data-driven mode, far from the cause).
2. **`init` trusted any existing collection unconditionally** — a half-configured collection was never repaired and poisoned every later run. `force` was also a silent no-op for plain existing collections (the alias-shadowing guard in `init()` early-returned before honoring it).

## Fix

- **Atomic rebuild**: `init_schema` now sends all deletes + adds in ONE Schema API request, which Solr applies as a single atomic schema update. The half-applied state can no longer exist. (`clear_all_schema` is also one request now; shared `clear_schema_commands` builder.)
- **Additive self-repair**: on init of an *existing* collection, anything the generator declares that is missing is added — in one atomic request, **never deleting or altering anything**. No-op when the schema is healthy. Tolerates concurrent process boots racing the same repair.
- **Deterministic test runs**: `Goo.force_rebuild_search_schema` (set by goo's test harness only) makes each collection's first init per test run rebuild its schema, so runs no longer inherit state from previous, possibly interrupted, runs.
- `test_solr.rb`: fixed a pre-existing `assert_equal(nil, nil)` trap in the multiValued assertions (fails on vanilla `development` too; deterministic once schemas rebuild per run).

## ⚠️ Production-safety analysis (please scrutinize)

This code path has wiped a live collection before, so the non-forced path was designed to be provably non-destructive and audited against the OLD boot workflow and `ncbo_cron/bin/ncbo_ontology_index`:

- Live collections carry **data-driven fields the generator does not declare** (Solr auto-adds a schema field per unknown doc key). A full rebuild would drop them from the schema and silently break search on them until a multi-day reindex. That is why repair is **add-missing-only**; the destructive rebuild exists solely behind explicit `force`.
- Audited init call sites: API/cron boot (`init_search_connections(force=false)`), `clear_indexed_content` → `:ontology_data`, `ncbo_ontology_index` `-a` (fresh collection, unchanged) / `--refresh-all` and `-o` (additive repair only) / `--promote-only` (never inits — `initialize_collection: false`). Nothing in OLD/cron/API passes `force: true` or sets the rebuild flag.
- Divergent-but-present items are deliberately left untouched (migration concern, not bootstrap repair).

## Testing

- Full suite green multiple consecutive runs (`172 runs, 3124 assertions, 0 failures`, 4store + local Solr/redis) — including back-to-back runs, the scenario that previously alternated.
- Poison/heal demo: deleted `*_str` from a live-like collection and added a `legacy_prod_field` unknown to the generator; `init(force=false)` restored `*_str` and **preserved** the foreign field.
