### PR TITLE
Perf: Use SPARQL VALUES for model ID restrictions

### DIFF
--- a/lib/goo/sparql/query_builder.rb
+++ b/lib/goo/sparql/query_builder.rb
@@ -156,13 +156,19 @@ module Goo
       end
 
       def ids_filter(ids)
-        filter_id = []
+        return self if ids.empty?
 
-        ids.each do |id|
-          filter_id << "?id = #{id.to_ntriples.to_s.gsub(' ', '%20').gsub("\\u0020", '%20')}"
+        if Goo.backend_4s?
+          filter = ids.map do |id|
+            "?id = #{id.to_ntriples.to_s.gsub(' ', '%20').gsub("\\u0020", '%20')}"
+          end
+          @query.filter filter.join(' || ')
+        else
+          values = ids.map do |id|
+            id.is_a?(RDF::URI) ? RDF::URI(id.to_s.gsub(' ', '%20')) : id
+          end
+          @query.values(:id, *values)
         end
-        filter_id_str = filter_id.join ' || '
-        @query.filter filter_id_str
         self
       end
 
@@ -454,4 +460,3 @@ module Goo
     end
   end
 end
-

--- a/test/test_query_builder.rb
+++ b/test/test_query_builder.rb
@@ -1,0 +1,79 @@
+require_relative 'test_case'
+
+class TestQueryBuilder < Goo::TestCase
+  class QueryBuilderProbe < Goo::SPARQL::QueryBuilder
+    attr_reader :query
+
+    def initialize
+      @query = SPARQL::Client::Query.select(:id)
+                                    .where([:id, RDF.type, RDF::URI('http://example.org/Resource')])
+    end
+  end
+
+  def test_ids_filter_uses_values_instead_of_a_disjunctive_filter
+    ids = [RDF::URI('http://example.org/one'), RDF::URI('http://example.org/two')]
+    builder = QueryBuilderProbe.new
+
+    with_4store(false) { builder.ids_filter(ids) }
+
+    query = builder.query.to_s
+    assert_includes query, 'VALUES (?id) { ( <http://example.org/one> ) ( <http://example.org/two> ) }'
+    refute_includes query, 'FILTER'
+    refute_includes query, '||'
+  end
+
+  def test_ids_filter_keeps_filter_fallback_for_4store
+    ids = [RDF::URI('http://example.org/one'), RDF::URI('http://example.org/two')]
+    builder = QueryBuilderProbe.new
+
+    with_4store(true) { builder.ids_filter(ids) }
+
+    query = builder.query.to_s
+    assert_includes query, 'FILTER(?id = <http://example.org/one> || ?id = <http://example.org/two>)'
+    refute_includes query, 'VALUES'
+  end
+
+  def test_ids_filter_is_a_no_op_for_an_empty_id_list
+    builder = QueryBuilderProbe.new
+    query_without_ids = builder.query.to_s
+
+    builder.ids_filter([])
+
+    assert_equal query_without_ids, builder.query.to_s
+    refute builder.query.options.key?(:values)
+  end
+
+  def test_ids_filter_preserves_percent_encoded_spaces_for_virtuoso
+    id = RDF::URI('http://example.org/with space')
+    builder = QueryBuilderProbe.new
+
+    with_4store(false) { builder.ids_filter([id]) }
+
+    query = builder.query.to_s
+    assert_includes query, '<http://example.org/with%20space>'
+    refute_includes query, '\u0020'
+    assert_equal 'http://example.org/with space', id.to_s
+  end
+
+  def test_ids_filter_keeps_large_id_sets_in_one_values_block
+    ids = 500.times.map { |index| RDF::URI("http://example.org/#{index}") }
+    builder = QueryBuilderProbe.new
+
+    with_4store(false) { builder.ids_filter(ids) }
+
+    values = builder.query.options.fetch(:values)
+    assert_equal [:id], values.first.map(&:name)
+    assert_equal ids, values.drop(1).flatten
+    assert_equal 1, builder.query.to_s.scan('VALUES').length
+  end
+
+  private
+
+  def with_4store(enabled)
+    original = Goo.method(:backend_4s?)
+    Goo.define_singleton_method(:backend_4s?) { enabled }
+    yield
+  ensure
+    Goo.define_singleton_method(:backend_4s?, original)
+  end
+end


### PR DESCRIPTION
## Summary

- Replace large disjunctive ID filters with SPARQL `VALUES` clauses on AllegroGraph, Virtuoso, and GraphDB.
- Retain the existing `FILTER` implementation for 4store, which accepts `VALUES` syntax but does not apply the restriction.
- Preserve percent-encoded spaces in RDF URIs and make empty ID collections a no-op.
- Add focused coverage for backend behavior, empty IDs, URI encoding, and 500-ID batches.

Implements #191.

## Verification

- Focused query-builder tests: 5 runs, 20 assertions
- `test:where`: 26 runs, 472 assertions
- Full test suite: 181 runs, 3,159 assertions
- RuboCop: no offenses

## Performance

Measured from a local API process (Ruby 3.2.10) against the staging AllegroGraph instance containing production-equivalent data. The comparison used Goo `development` at `cc806c8` and this branch at `cb0b87b`.

For each exact 500-ID SPARQL query, the benchmark used 5 warmups followed by 50 alternating measured requests per revision over persistent HTTP connections. The before/after result bindings were identical.

| Workload | Query bytes (before → after) | Median (before → after) | p95 (before → after) |
| --- | ---: | ---: | ---: |
| UBERON classes | 29,361 → 26,873 (-8.5%) | 190.8 ms → 186.3 ms (-2.4%) | 206.1 ms → 200.9 ms (-2.5%) |
| NCIT classes | 36,520 → 34,032 (-6.8%) | 238.2 ms → 233.4 ms (-2.1%) | 272.5 ms → 286.7 ms (+5.2%) |

An end-to-end UBERON API benchmark (3 warmups, 20 alternating measured requests per revision) was effectively flat: median response time was 732.1 ms before and 736.9 ms after.

The measured benefit is therefore a consistent 6.8–8.5% reduction in generated query size and about a 2% improvement in query median latency for these workloads. Tail latency was mixed, and this benchmark does not demonstrate a material end-to-end API speedup.