### PR TITLE
feat: put bulk-load batch progress behind a debug flag

### DIFF
--- a/config/config.rb.sample
+++ b/config/config.rb.sample
@@ -25,6 +25,11 @@ Goo.config do |config|
   # whether it is published to API callers.
   config.queries_debug       = false
 
+  # Per-batch progress lines while bulk-loading triples (env: GOO_DATA_LOAD_DEBUG). Off by
+  # default: append_triples_batch emits one line per batch, and a single unit test in a
+  # dependent gem produces dozens of them. Turn on when debugging a slow or failing load.
+  # config.data_load_debug   = true
+
   # SPARQL query logging (off by default; env equivalent OP_QUERIES_LOGGING).
   # config.query_logging      = true
   # config.query_logging_file = '/var/log/goo/sparql.log'

--- a/lib/goo.rb
+++ b/lib/goo.rb
@@ -53,6 +53,7 @@ module Goo
   @@pluralize_models = false
   @@uuid = UUID.new
   @@debug_enabled = false
+  @@data_load_debug = false
   @@use_cache = false
   @@query_logging = false
   @@query_logging_file = nil
@@ -212,6 +213,17 @@ module Goo
 
   def self.queries_debug?
     return @@debug_enabled
+  end
+
+  # Per-batch progress lines during bulk triple loading. Off by default: append_triples_batch
+  # emits one line per chunk, which drowns the unit-test output of dependent gems
+  # (ontologies_linked_data) in thousands of lines that say nothing about the test.
+  def self.data_load_debug(flag)
+    @@data_load_debug = flag
+  end
+
+  def self.data_load_debug?
+    return @@data_load_debug
   end
 
   def self.add_search_backend(name, *opts)

--- a/lib/goo/config/config.rb
+++ b/lib/goo/config/config.rb
@@ -42,6 +42,10 @@ module Goo
     @settings.query_logging_max_logs ||= (ENV['OP_QUERIES_LOGGING_MAX_LOGS'] || 10_000).to_i
     @settings.query_logging_ttl        ||= (ENV['OP_QUERIES_LOGGING_TTL'] || 86_400).to_i
     @settings.queries_debug       ||= ENV['QUERIES_DEBUG'] || false
+    # Bulk-load progress lines (one per triple batch). Parse truthiness rather than taking the
+    # raw string -- GOO_DATA_LOAD_DEBUG=false is a non-empty String and would otherwise turn the
+    # output ON (same treatment as query_logging above).
+    @settings.data_load_debug     ||= %w[1 true yes on].include?(ENV['GOO_DATA_LOAD_DEBUG'].to_s.strip.downcase)
     # SPARQL query caching: goo default OFF; env-driven opt-in so production can flip caching
     # without a code change (de-fork review D5).
     @settings.use_cache           ||= %w[1 true yes on].include?(ENV['OP_USE_CACHE'].to_s.strip.downcase)
@@ -65,6 +69,7 @@ module Goo
     begin
       Goo.configure do |conf|
         conf.queries_debug(@settings.queries_debug)
+        conf.data_load_debug(@settings.data_load_debug)
         conf.add_sparql_backend(:main,
                                 backend_name: @settings.goo_backend_name,
                                 query: "http://#{@settings.goo_host}:#{@settings.goo_port}#{@settings.goo_path_query}",

--- a/lib/goo/sparql/client.rb
+++ b/lib/goo/sparql/client.rb
@@ -186,7 +186,7 @@ module Goo
 
       def append_triples_batch(graph, triples, mime_type_in, current_line = 0)
         begin
-          puts "Appending triples in batch of #{triples.size} triples from line #{current_line}"
+          puts "Appending triples in batch of #{triples.size} triples from line #{current_line}" if Goo.data_load_debug?
           execute_append_request graph, triples.join, mime_type_in
         rescue RestClient::Exception => e
           puts "Error in appending triples request: #{e.response}"


### PR DESCRIPTION
## Problem

`append_triples_batch` printed a progress line for every batch, unconditionally. Running a single unit test in a dependent gem (`ontologies_linked_data`) produces dozens of them:

```
TestAncestorsPrecompute#test_memoization = 0.00 s = .
Appending triples in batch of 146449 triples from line 0
Appending triples in batch of 5 triples from line 0
Appending triples in batch of 1698 triples from line 0
... (dozens more)
```

The information is useful when debugging a slow or failing ontology load, and noise everywhere else.

## Change

Adds a `data_load_debug` flag, following the shape of the existing `queries_debug` switch directly above it:

- `Goo.data_load_debug` / `Goo.data_load_debug?` in `lib/goo.rb`
- `GOO_DATA_LOAD_DEBUG` env var, plumbed through `config.rb` and documented in `config.rb.sample`
- the `puts` at `lib/goo/sparql/client.rb:189` is now guarded by it

**Off by default in `lib/goo.rb` itself**, so callers that never reach `Goo.config` — unit tests in dependent gems, notably — get the quiet default with no change on their side. Opt back in with `GOO_DATA_LOAD_DEBUG=true` or a direct `Goo.data_load_debug(true)`.

## Notes for review

- The setter is positional (`data_load_debug(flag)`) rather than `data_load_debug=`, because it is called inside a `Goo.configure` block where `conf.x = v` would parse as a local variable assignment rather than a method call. This matches `queries_debug`.
- The env var is parsed for truthiness (`%w[1 true yes on].include?`) rather than taken raw. The neighbouring `queries_debug` line uses the raw form, where `QUERIES_DEBUG=false` is a non-empty String and therefore turns debug *on*; this is the same trap already called out in the `query_logging` comment. That pre-existing line is left alone here.
- The **error**-path `puts` calls in the same method are deliberately untouched. They report real failures and must not be gated behind a debug flag. Whether they belong on stderr (`warn`, as `resilience.rb` and `cache.rb` already do) is a separate question, intentionally left out of this PR.

## Verification

- flag defaults to `false`, and toggles correctly
- env parsing accepts `1` / `true` / `on` / `YES`; rejects `false` / `FALSE` / `0` / `no` / unset
- calling `append_triples_batch` with a stubbed network call prints nothing when off, and exactly one line when on
- `config.rb.sample` loads and yields `false` as shipped, `true` with the line uncommented
- `test/test_cache_unit.rb` passes (17 tests, 43 assertions, 0 failures)

No automated test accompanies the flag; happy to add one covering the env parsing if reviewers would prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)